### PR TITLE
Settings: Replace deprecated flag `-intra` for `-g 1`

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -108,7 +108,7 @@ DEFAULT_PUBLISH_PLUGINS = {
               "output": [
                 "-pix_fmt yuv420p",
                 "-crf 18",
-                "-intra"
+                "-g 1",
               ]
             }
         }


### PR DESCRIPTION
### Changes

Replace deprecated flag `-intra` for `-g 1` for FFMPEG encoding.

Matches a similar change in `ayon-core` code here: https://github.com/ynput/ayon-core/pull/758

See:
- https://gist.github.com/tayvano/6e2d456a9897f55025e25035478a3a50#file-gistfile1-txt-L67
- https://www.reddit.com/r/ffmpeg/comments/aeo1la/libx264_intra_option_information_please/

---

This changes default for setting: `ayon+settings://traypublisher/publish/ExtractEditorialPckgConversion/output/ffmpeg_args/output`

Note that this just replaces the default value, if you have settings overrides for this flag you may need to remove your override your updates or update manually.

### Testing notes

1. Extracting Editorial Package `editorial_pkg` should still work with the new FFMPEG encoding settings.

