### PR TITLE
Fix deprecated opentimelineio 'each_child' methods (To Be Discussed).

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial.py
@@ -351,11 +351,7 @@ or updating already created. Publishing will create OTIO file.
             product_type_presets (list): list of dict settings product presets
         """
 
-        tracks = [
-            track for track in otio_timeline.each_child(
-                descended_from_type=otio.schema.Track)
-            if track.kind == "Video"
-        ]
+        tracks = otio_timeline.video_tracks
 
         # media data for audio stream and reference solving
         media_data = self._get_media_source_metadata(media_path)
@@ -372,7 +368,7 @@ or updating already created. Publishing will create OTIO file.
             except AttributeError:
                 track_start_frame = 0
 
-            for otio_clip in track.each_child():
+            for otio_clip in track.find_clips():
                 if not self._validate_clip_for_processing(otio_clip):
                     continue
 

--- a/client/ayon_traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial.py
@@ -351,7 +351,7 @@ or updating already created. Publishing will create OTIO file.
             product_type_presets (list): list of dict settings product presets
         """
 
-        tracks = otio_timeline.video_tracks
+        tracks = otio_timeline.video_tracks()
 
         # media data for audio stream and reference solving
         media_data = self._get_media_source_metadata(media_path)

--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -74,8 +74,7 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
         otio_timeline = context.data["otioTimeline"]
 
         clips = [
-            clip for clip in otio_timeline.each_child(
-                descended_from_type=otio.schema.Clip)
+            clip for clip in otio_timeline.find_clips()
             if clip.name == otio_clip.name
             if clip.parent().kind == "Video"
         ]


### PR DESCRIPTION
## Changelog Description
When onboarding for the Resolve publisher work, I tried to make the `EditorialSimple` example working from the `traypublisher` but go some issues.
``` text
AttributeError: 'opentimelineio._otio.Timeline' object has no attribute 'each_child'
```

I'm using `opentimelineio-0.16.0` which I believe is defined from 
https://github.com/ynput/ayon-core/blob/874a0f1c4e308ec93828b8eef0487591b8ffd782/client/pyproject.toml#L17

So I think this is an issue which needs to be fixed, please @jakubjezek001 advise on this one :smiley: 

## Additional info

OpentimelineIO PR which remove `each_child`:
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/pull/1437/files

## Testing notes:

1. Try to create an `EditorialSimple` from test resources
