### PR TITLE
Update default product type for the VDB cache simple creator

### DIFF
--- a/server/settings/simple_creators.py
+++ b/server/settings/simple_creators.py
@@ -228,7 +228,7 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "vdb",
+        "product_type": "vdbcache",
         "identifier": "",
         "label": "VDB Volumes",
         "icon": "fa.cloud",


### PR DESCRIPTION
## Changelog Description

The 'vdbcache' product type is used for product types filtering currently for Houdini and Maya based loaders so is a way more sensible default.

## Additional info

I don't know of any loader that would work with the `vdb` product type currently.

## Testing notes:

1. Publish VDB via tray publisher
2. Should be able to load it into Maya and Houdini
