### PR TITLE
Use task entity attributes instead of folder entity attributes

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
@@ -2,14 +2,14 @@ import pyblish.api
 
 
 class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin):
-    """Collect Frame Data From 'folderEntity' found in context.
+    """Collect Frame Data From `taskEntity` or `folderEntity` of instance.
 
-    Frame range data will only be collected if the keys
-    are not yet collected for the instance.
+    Frame range data will only be collected if the keys are not yet
+    collected for the instance.
     """
 
     order = pyblish.api.CollectorOrder + 0.491
-    label = "Collect Missing Frame Data From Folder"
+    label = "Collect Missing Frame Data From Folder/Task"
     families = [
         "plate",
         "pointcache",
@@ -38,14 +38,20 @@ class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin):
             return
 
         keys_set = []
-        folder_attributes = instance.data["folderEntity"]["attrib"]
+
+        folder_entity = instance.data["folderEntity"]
+        task_entity = instance.data.get("taskEntity")
+        context_attributes = (
+            task_entity["attrib"] if task_entity else folder_entity["attrib"]
+        )
+
         for key in missing_keys:
-            if key in folder_attributes:
-                instance.data[key] = folder_attributes[key]
+            if key in context_attributes:
+                instance.data[key] = context_attributes[key]
                 keys_set.append(key)
 
         if keys_set:
             self.log.debug(
                 f"Frame range data {keys_set} "
-                "has been collected from folder entity."
+                "has been collected from folder (or task) entity."
             )

--- a/client/ayon_traypublisher/plugins/publish/collect_review_frames.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_review_frames.py
@@ -20,12 +20,16 @@ class CollectReviewInfo(pyblish.api.InstancePlugin):
     hosts = ["traypublisher"]
 
     def process(self, instance):
-        folder_entity = instance.data.get("folderEntity")
-        if instance.data.get("frameStart") is not None or not folder_entity:
+
+        entity = (
+            instance.data.get("taskEntity")
+            or instance.data.get("folderEntity")
+        )
+        if instance.data.get("frameStart") is not None or not entity:
             self.log.debug("Missing required data on instance")
             return
 
-        folder_attributes = folder_entity["attrib"]
+        context_attributes = entity["attrib"]
         # Store collected data for logging
         collected_data = {}
         for key in (
@@ -35,9 +39,9 @@ class CollectReviewInfo(pyblish.api.InstancePlugin):
             "handleStart",
             "handleEnd",
         ):
-            if key in instance.data or key not in folder_attributes:
+            if key in instance.data or key not in context_attributes:
                 continue
-            value = folder_attributes[key]
+            value = context_attributes[key]
             collected_data[key] = value
             instance.data[key] = value
         self.log.debug("Collected data: {}".format(str(collected_data)))

--- a/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
@@ -49,7 +49,11 @@ class CollectSequenceFrameData(
 
     def get_frame_data_from_repre_sequence(self, instance):
         repres = instance.data.get("representations")
-        folder_attributes = instance.data["folderEntity"]["attrib"]
+
+        entity: dict = (
+            instance.data.get("taskEntity") or instance.data["folderEntity"]
+        )
+        entity_attributes: dict = entity["attrib"]
 
         if repres:
             first_repre = repres[0]
@@ -78,5 +82,5 @@ class CollectSequenceFrameData(
                 "frameEnd": repres_frames[-1],
                 "handleStart": 0,
                 "handleEnd": 0,
-                "fps": folder_attributes["fps"]
+                "fps": entity_attributes["fps"]
             }

--- a/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -47,11 +47,15 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
                 for pattern in self.skip_timelines_check)):
             self.log.info("Skipping for {} task".format(instance.data["task"]))
 
-        folder_attributes = instance.data["folderEntity"]["attrib"]
-        frame_start = folder_attributes["frameStart"]
-        frame_end = folder_attributes["frameEnd"]
-        handle_start = folder_attributes["handleStart"]
-        handle_end = folder_attributes["handleEnd"]
+        # Use attributes from task entity if set, otherwise from folder entity
+        entity = (
+            instance.data.get("taskEntity") or instance.data["folderEntity"]
+        )
+        attributes = entity["attrib"]
+        frame_start = attributes["frameStart"]
+        frame_end = attributes["frameEnd"]
+        handle_start = attributes["handleStart"]
+        handle_end = attributes["handleEnd"]
         duration = (frame_end - frame_start + 1) + handle_start + handle_end
 
         repres = instance.data.get("representations")
@@ -73,7 +77,7 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
 
         msg = (
             "Frame duration from DB:'{}' doesn't match number of files:'{}'"
-            " Please change frame range for Folder or limit no. of files"
+            " Please change frame range for folder/task or limit no. of files"
         ). format(int(duration), frames)
 
         formatting_data = {"duration": duration,


### PR DESCRIPTION
## Changelog Description

Use task entity attributes instead of folder entity attributes, only if it is set for the instance.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

I'm not sure if I've missed any parts where it's also crucial to refactor them in `traypublisher`. This is mostly a bit of 'search' in the code to see where `folder` seems relevant to update.

## Testing notes:

Not entirely sure how to test these use cases.

1. Test tray publisher sequences and their "assumed" frame ranges.
