### PR TITLE
AY-6740 CSV ingest: make Version column optional.

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -55,7 +55,7 @@ def _get_row_value_with_validation(
     # get column default value
     column_default = column_data["default"]
 
-    if column_type in ["number", "decimal"] and column_default == 0:
+    if column_type in ["number", "decimal"] and column_default in (0, '0'):
         column_default = None
 
     # check if column value is not empty string
@@ -779,7 +779,11 @@ configuration in project settings.
                 product_item.product_type,
                 product_item.variant
             )
-            label: str = f"{folder_path}_{product_name}_v{version:>03}"
+
+            if version is not None:
+                label: str = f"{folder_path}_{product_name}_v{version:>03}"
+            else:
+                label: str = f"{folder_path}_{product_name}_v[next]"
 
             repre_items: List[RepreItem] = product_item.repre_items
             first_repre_item: RepreItem = repre_items[0]

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -182,7 +182,7 @@ DEFAULT_CREATORS = {
                     "type": "text",
                     "default": "",
                     "required_column": True,
-                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#._\\\\/]*)$"
+                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#-._\\\\/]*)$"
                 },
                 {
                     "name": "Folder Path",
@@ -215,8 +215,8 @@ DEFAULT_CREATORS = {
                 {
                     "name": "Version",
                     "type": "number",
-                    "default": "1",
-                    "required_column": True,
+                    "default": "0",
+                    "required_column": False,
                     "validation_pattern": "^(\\d{1,3})$"
                 },
                 {
@@ -231,7 +231,7 @@ DEFAULT_CREATORS = {
                     "type": "text",
                     "default": "",
                     "required_column": False,
-                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#._\\\\/]*)$"
+                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#-._\\\\/]*)$"
                 },
                 {
                     "name": "Frame Start",

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -182,7 +182,7 @@ DEFAULT_CREATORS = {
                     "type": "text",
                     "default": "",
                     "required_column": True,
-                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#-._\\\\/]*)$"
+                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#\\-\\._\\\\/]*)$"
                 },
                 {
                     "name": "Folder Path",
@@ -231,7 +231,7 @@ DEFAULT_CREATORS = {
                     "type": "text",
                     "default": "",
                     "required_column": False,
-                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#-._\\\\/]*)$"
+                    "validation_pattern": "^([a-zA-Z\\:\\ 0-9#\\-\\._\\\\/]*)$"
                 },
                 {
                     "name": "Frame Start",


### PR DESCRIPTION
## Changelog Description

These changes resolves #16 
Ensure the Version column in the CSV is optional:
* _When it exists and it's filled up,_ will publish and enforce provided version (**previous behavior**)
* _When it exists but it's empty,_ product will take next available version
* _When it does not exist,_ default logic applies, product will take next available version


## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->


## Testing notes:

Tested via the command line and interactive mode using:
* [AY_240319_0001_ABS - ay_240319_0001_abs_paths_60_empty.csv](https://github.com/user-attachments/files/17298103/AY_240319_0001_ABS.-.ay_240319_0001_abs_paths_60_empty.csv)  column exists but empty
* [AY_240319_0001_ABS - ay_240319_0001_abs_paths_60_mixed.csv](https://github.com/user-attachments/files/17298104/AY_240319_0001_ABS.-.ay_240319_0001_abs_paths_60_mixed.csv)  mix of version number and empty
* [AY_240319_0001_ABS - ay_240319_0001_abs_paths_no_version.csv](https://github.com/user-attachments/files/17298105/AY_240319_0001_ABS.-.ay_240319_0001_abs_paths_no_version.csv) version column missing

[How to use the CSV CLI interface](https://ayon.ynput.io/docs/addon_traypublisher_admin/#cli-interface)

1. Create the relevant shot hierarchy in the project
2. Ensure CSV settings are properly set and OCIO config is enabled
3. Download [resource material](https://github.com/ynput/ayon-core/files/14651928/ay_240319_0001.zip) and edit CSV to point toward downloading paths
4. Run the CSV ingest via CLI or interactive mode (traypublisher)
