### PR TITLE
CSV ingest allow user override through AYON_USERNAME.

### DIFF
--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -115,9 +115,10 @@ def ingestcsv(
     # Allow user override through AYON_USERNAME when
     # current connection is made through a service user.
     username = os.environ.get("AYON_USERNAME")
-    con = ayon_api.get_server_api_connection()
-    if username and con.is_service_user():
-        con.set_default_service_username(username)
+    if username:
+        con = ayon_api.get_server_api_connection()
+        if con.is_service_user():
+            con.set_default_service_username(username)
 
     # use Path to check if csv_filepath exists
     if not Path(filepath).exists():

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -1,6 +1,9 @@
 import os
 
 from pathlib import Path
+
+import ayon_api
+
 from ayon_core.lib import get_ayon_launcher_args
 from ayon_core.lib.execute import run_detached_process
 from ayon_core.addon import (
@@ -108,6 +111,13 @@ def ingestcsv(
     specific format. See documentation for more information.
     """
     from .csv_publish import csvpublish
+
+    # Allow user override through AYON_USERNAME when
+    # current connection is made through a service user.
+    username = os.environ.get("AYON_USERNAME")
+    con = ayon_api.get_server_api_connection()
+    if username and con.is_service_user():
+        con.set_default_service_username(username)
 
     # use Path to check if csv_filepath exists
     if not Path(filepath).exists():


### PR DESCRIPTION
## Changelog Description

resolve #34 
The user should be able to override the user operating the CSV ingest through `AYON_USERNAME` when connection is made through a service account. 


## Additional info


## Testing notes:

1. Setup connection through a service account
2. Set `AYON_USERNAME` environment variable to an existing user
3. Run the CSV ingest command line
4. Check that the created product are made under the user set through `AYON_USERNAME`
