### PR TITLE
Allow CSV ingest to create new shots.

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -850,8 +850,8 @@ configuration in project settings.
             str. The task type computed from settings.
         """
         for task_setting in self.folder_creation_config["task_type_regexes"]:
-            if re.match(task_setting["regex"], name):
-                folder_type = task_setting["task_type"]
+            if re.match(task_setting["regex"], task_name):
+                task_type = task_setting["task_type"]
                 break
         else:
             task_type = self.folder_creation_config["task_create_type"]

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -429,6 +429,7 @@ configuration in project settings.
         for path in parent_paths:
             folder_entity = folders_by_path.get(path)
             name = path.rsplit("/", 1)[-1]
+            folder_type = None
 
             # Folder exists, retrieve data from existing.
             if folder_entity:
@@ -440,13 +441,14 @@ configuration in project settings.
                     if re.match(folder_setting["regex"], name):
                         folder_type = folder_setting["folder_type"]
                         break
-                else:
-                    folder_type = "Folder"  # default
 
-            parent_data.append({
-                "folder_type": folder_type,
-                "entity_name": name
-            })
+            item = {
+                "entity_name": name,
+            }
+            if folder_type:
+                item["folder_type"] = folder_type
+
+            parent_data.append(item)
 
         return parent_data
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -174,6 +174,14 @@ class FolderCreationConfigModel(BaseSettingsModel):
         )
     )
 
+    folder_create_type: str = SettingsField(
+        "Folder",
+        title="Default Folder Type",
+        enum_resolver=folder_types_enum,
+        description=(
+            "Default folder type for new folder(s) creation."),
+    )
+
     task_type_regexes: list[TaskTypeRegexItem] = SettingsField(
         default_factory=TaskTypeRegexItem,
         description=(
@@ -412,6 +420,7 @@ DEFAULT_CREATORS = {
                 {"regex": "(sh.*)", "folder_type": "Shot"},
                 {"regex": "(seq.*)", "folder_type": "Sequence"}
             ],
+            "folder_create_type": "Folder",
             "task_type_regexes": [],
             "task_create_type": "Generic",
         }

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -2,7 +2,8 @@ from pydantic import validator
 from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
-    folder_types_enum
+    folder_types_enum,
+    task_types_enum,
 )
 from ayon_server.settings.validators import ensure_unique_names
 from ayon_server.exceptions import BadRequestException
@@ -144,6 +145,18 @@ class FolderTypeRegexItem(BaseSettingsModel):
     )
 
 
+class TaskTypeRegexItem(BaseSettingsModel):
+    _layout = "expanded"
+    regex: str = SettingsField("", title="Task Regex")
+    task_type: str = SettingsField(
+        "",
+        title="Task Type",
+        enum_resolver=task_types_enum,
+        description=(
+            "New task type to create when regex matches."),
+    )
+
+
 class FolderCreationConfigModel(BaseSettingsModel):
     """Allow to create folder hierarchy when non-existing."""
 
@@ -159,6 +172,23 @@ class FolderCreationConfigModel(BaseSettingsModel):
             " to define which folder types are used for new folder creation"
             " depending on their names."
         )
+    )
+
+    task_type_regexes: list[TaskTypeRegexItem] = SettingsField(
+        default_factory=TaskTypeRegexItem,
+        description=(
+            "Using Regex expressions to create missing tasks. \nThose can be used"
+            " to define which task types are used for new folder+task creation"
+            " depending on their names."
+        )
+    )
+
+    task_create_type: str = SettingsField(
+        "",
+        title="Default Task Type",
+        enum_resolver=task_types_enum,
+        description=(
+            "Default task type for new task(s) creation."),
     )
 
 
@@ -382,6 +412,8 @@ DEFAULT_CREATORS = {
                 {"regex": "(sh.*)", "folder_type": "Shot"},
                 {"regex": "(seq.*)", "folder_type": "Sequence"}
             ],
+            "task_type_regexes": [],
+            "task_create_type": "Generic",
         }
     }
 }

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,5 +1,9 @@
 from pydantic import validator
-from ayon_server.settings import BaseSettingsModel, SettingsField
+from ayon_server.settings import (
+    BaseSettingsModel,
+    SettingsField,
+    folder_types_enum
+)
 from ayon_server.settings.validators import ensure_unique_names
 from ayon_server.exceptions import BadRequestException
 
@@ -131,7 +135,13 @@ class RepresentationConfigModel(BaseSettingsModel):
 class FolderTypeRegexItem(BaseSettingsModel):
     _layout = "expanded"
     regex: str = SettingsField("", title="Folder Regex")
-    folder_type: str = SettingsField("", title="Folder Type")
+    folder_type: str = SettingsField(
+        "Folder",
+        title="Folder Type",
+        enum_resolver=folder_types_enum,
+        description=(
+            "Project's Anatomy folder type to create when regex matches."),
+    )
 
 
 class FolderCreationConfigModel(BaseSettingsModel):
@@ -175,7 +185,7 @@ class IngestCSVPluginModel(BaseSettingsModel):
     folder_creation_config: FolderCreationConfigModel = SettingsField(
         title="Folder creation config",
         default_factory=FolderCreationConfigModel
-    )    
+    )
 
 
 class TrayPublisherCreatePluginsModel(BaseSettingsModel):
@@ -372,6 +382,6 @@ DEFAULT_CREATORS = {
                 {"regex": "(sh.*)", "folder_type": "Shot"},
                 {"regex": "(seq.*)", "folder_type": "Sequence"}
             ],
-        }        
+        }
     }
 }

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -128,6 +128,30 @@ class RepresentationConfigModel(BaseSettingsModel):
         return value
 
 
+class FolderTypeRegexItem(BaseSettingsModel):
+    _layout = "expanded"
+    regex: str = SettingsField("", title="Folder Regex")
+    folder_type: str = SettingsField("", title="Folder Type")
+
+
+class FolderCreationConfigModel(BaseSettingsModel):
+    """Allow to create folder hierarchy when non-existing."""
+
+    enabled: bool = SettingsField(
+        title="Enabled folder creation",
+        default=False,
+    )
+
+    folder_type_regexes: list[FolderTypeRegexItem] = SettingsField(
+        default_factory=FolderTypeRegexItem,
+        description=(
+            "Using Regex expressions to create missing folders. \nThose can be used"
+            " to define which folder types are used for new folder creation"
+            " depending on their names."
+        )
+    )
+
+
 class IngestCSVPluginModel(BaseSettingsModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
      asset is parsed from file names ('asset.mov', 'asset_v001.mov',
@@ -147,6 +171,11 @@ class IngestCSVPluginModel(BaseSettingsModel):
         title="Representations config",
         default_factory=RepresentationConfigModel
     )
+
+    folder_creation_config: FolderCreationConfigModel = SettingsField(
+        title="Folder creation config",
+        default_factory=FolderCreationConfigModel
+    )    
 
 
 class TrayPublisherCreatePluginsModel(BaseSettingsModel):
@@ -336,6 +365,13 @@ DEFAULT_CREATORS = {
                     ]
                 }
             ]
-        }
+        },
+        "folder_creation_config": {
+            "enabled": False,
+            "folder_type_regexes": [
+                {"regex": "(sh.*)", "folder_type": "Shot"},
+                {"regex": "(seq.*)", "folder_type": "Sequence"}
+            ],
+        }        
     }
 }


### PR DESCRIPTION
## Changelog Description

resolve #24

#### New features:
* Allow CSV ingest to create new shots for non-existent folder paths
* Provide additional server settings for Folder and Task creation

![image](https://github.com/user-attachments/assets/37173538-6563-4853-b32e-781a0d38cb58)


## Additional review information

**Current implementation has some limitations**:
* Created shot are pretty much blank as we do not have any OTIO/range/resolution info from the CSV file

## Testing notes:
This needs to be tested along those changes in `ayon_core`: https://github.com/ynput/ayon-core/pull/1010

1. Create a new package and upload it to your AYON server
2. In CSV settings, enable missing folder creation (`ayon+settings://traypublisher/create/IngestCSV/folder_creation_config`)
3. Prepare a CSV file with Folder Path that do not exist yet
4. Ingest the CSV file through the `publisher` option in traypublisher
5. Ensure data is publish as expected and new blank shot(s) have been created
