### PR TITLE
Expose `Collect Original Sequence Frame Data` settings in Addon settings

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -61,6 +61,10 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
         default_factory=ValidatePluginModel,
         title="Collect Frame Data From Folder Entity",
     )
+    CollectSequenceFrameData: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
+        title="Collect Original Sequence Frame Data",
+    )
     ValidateFrameRange: ValidateFrameRangeModel = SettingsField(
         title="Validate Frame Range",
         default_factory=ValidateFrameRangeModel,
@@ -80,6 +84,11 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 DEFAULT_PUBLISH_PLUGINS = {
     "CollectFrameDataFromAssetEntity": {
+        "enabled": True,
+        "optional": True,
+        "active": True
+    },
+    "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,
         "active": True


### PR DESCRIPTION
## Changelog Description
resolve #41 

## Testing notes:
1. Go to setting `ayon+settings://traypublisher/publish/CollectSequenceFrameData` 
2. Try enabling and disabling different toggles, this should be reflected in the publisher UI.
