### PR TITLE
remove redundant settings from `CollectFrameDataFromAssetEntity`

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,6 +11,11 @@ class ValidatePluginModel(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
+class MiniValidatePluginModel(BaseSettingsModel):
+    
+    enabled: bool = True
+
+
 class ValidateFrameRangeModel(ValidatePluginModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
      asset is parsed from file names ('asset.mov', 'asset_v001.mov',
@@ -57,8 +62,8 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectFrameDataFromAssetEntity: ValidatePluginModel = SettingsField(
-        default_factory=ValidatePluginModel,
+    CollectFrameDataFromAssetEntity: MiniValidatePluginModel = SettingsField(
+        default_factory=MiniValidatePluginModel,
         title="Collect Frame Data From Folder Entity",
     )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(
@@ -85,8 +90,6 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 DEFAULT_PUBLISH_PLUGINS = {
     "CollectFrameDataFromAssetEntity": {
         "enabled": True,
-        "optional": True,
-        "active": True
     },
     "CollectSequenceFrameData": {
         "enabled": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,8 +11,7 @@ class ValidatePluginModel(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
-class MiniValidatePluginModel(BaseSettingsModel):
-    
+class EnabledStateModel(BaseSettingsModel):
     enabled: bool = True
 
 
@@ -62,8 +61,8 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectFrameDataFromAssetEntity: MiniValidatePluginModel = SettingsField(
-        default_factory=MiniValidatePluginModel,
+    CollectFrameDataFromAssetEntity: EnabledStateModel = SettingsField(
+        default_factory=EnabledStateModel,
         title="Collect Frame Data From Folder Entity",
     )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,10 +11,6 @@ class ValidatePluginModel(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
-class EnabledStateModel(BaseSettingsModel):
-    enabled: bool = True
-
-
 class ValidateFrameRangeModel(ValidatePluginModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
      asset is parsed from file names ('asset.mov', 'asset_v001.mov',
@@ -61,10 +57,6 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectFrameDataFromAssetEntity: EnabledStateModel = SettingsField(
-        default_factory=EnabledStateModel,
-        title="Collect Frame Data From Folder Entity",
-    )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect Original Sequence Frame Data",
@@ -87,9 +79,6 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
-    "CollectFrameDataFromAssetEntity": {
-        "enabled": True,
-    },
     "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,


### PR DESCRIPTION
## Changelog Description
resolve #50 
This PR removes `CollectFrameDataFromAssetEntity` settings completely.  this plugin was previously Optional, but that got later removed https://github.com/ynput/OpenPype/commit/e90d227a234fec278b214c3ed4086350403eda80


## Testing notes:
1. everything should work as before. 
2. Please report if the missing logic should be implemented instead of removing the redundant settings.
3. Please report if the PR is not backward compatible (copy settings should work fine without implementing conversions)
