### PR TITLE
Fix default values of `ExtractEditorialPckgConversion`

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -95,10 +95,9 @@ DEFAULT_PUBLISH_PLUGINS = {
         "active": True
     },
     "ExtractEditorialPckgConversion": {
-        "optional": False,
-        "conversion_enabled": True,
+        "conversion_enabled": False,
         "output": {
-            "ext": "",
+            "ext": "mp4",
             "ffmpeg_args": {
               "video_filters": [],
               "audio_filters": [],


### PR DESCRIPTION
## Changelog Description
resolve #53 
![image](https://github.com/user-attachments/assets/d2169ce5-67fa-46bf-9c41-b8b97fa92ebf)


## Testing notes:
1. when enabled, the conversion should work. 
2. the setting should be backward compatible, copy settings should be fine.