### PR TITLE
Enhance editorial creator settings and creator attributes

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_editorial.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial.py
@@ -869,7 +869,7 @@ or updating already created. Publishing will create OTIO file.
                 label="Timeline offset"
             ),
             UISeparatorDef(),
-            UILabelDef("Clip instance attributes"),
+            UILabelDef("Add products for each discovered shot"),
             UISeparatorDef()
         ]
         # add variants swithers

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -47,19 +47,20 @@ parent_type_enum = [
 class TokenToParentConvertorItem(BaseSettingsModel):
     _layout = "compact"
     # TODO - was 'type' must be renamed in code to `parent_type`
-    parent_type: str = SettingsField(
-        "Project",
-        enum_resolver=lambda: parent_type_enum
-    )
     name: str = SettingsField(
         "",
-        title="Parent token name",
+        title="Token name",
         description="Unique name used in `Parent path template`"
     )
     value: str = SettingsField(
         "",
-        title="Parent token value",
+        title="Token value",
         description="Template where any text, Anatomy keys and Tokens could be used"  # noqa
+    )
+    parent_type: str = SettingsField(
+        "Project",
+        title="Folder Type",
+        enum_resolver=lambda: parent_type_enum
     )
 
 

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -115,9 +115,9 @@ class EditorialSimpleCreatorPlugin(BaseSettingsModel):
         default_factory=ClipNameTokenizerItem,
         description="""Clip Name Tokenizer Info.
 
-                    Use Regex expression to create tokens.
-                    Those can be used  later in `Shot rename` creator or `Shot hierarchy`.
-                    Tokens should be enclosed by `_` on each side.
+                    Use regex expressions to create tokens.
+                    These tokens will be used later in the `Shot rename` creator or `Shot hierarchy`.
+                    Each token must be enclosed by underscores (`_`).
                     """
     )    
     shot_rename: ShotRenameSubmodel = SettingsField(

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -72,7 +72,9 @@ class ShotHierarchySubmodel(BaseSettingsModel):
     The `Folder path template` supports tokens defined in the `folder path template tokens` setting.
 
     - Each token in the `Folder path template` represents a folder in the hierarchy.
-    - Each token can leverage tokens defined in the `Clip Name Tokenizer`.
+    - Each token's value supports both the available 
+    [template keys](https://ayon.ynput.io/docs/admin_settings_project_anatomy#available-template-keys) 
+    and tokens defined in the `Clip Name Tokenizer`.
     """
     enabled: bool = True
     parents_path: str = SettingsField(

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -7,13 +7,13 @@ from ayon_server.settings import (
 
 class ClipNameTokenizerItem(BaseSettingsModel):
     _layout = "compact"
-    name: str = SettingsField("", title="Tokenizer name")
-    regex: str = SettingsField("", title="Tokenizer regex")
+    name: str = SettingsField("", title="Token name")
+    regex: str = SettingsField("", title="Token regex")
 
 
 class ShotAddTasksItem(BaseSettingsModel):
     _layout = "compact"
-    name: str = SettingsField('', title="Key")
+    name: str = SettingsField('', title="Task Name")
     task_type: str = SettingsField(
         title="Task type",
         enum_resolver=task_types_enum
@@ -21,6 +21,14 @@ class ShotAddTasksItem(BaseSettingsModel):
 
 
 class ShotRenameSubmodel(BaseSettingsModel):
+    """Shot Rename Info
+
+    When enabled, any discovered shots will be renamed based on the `shot rename template`.
+
+    The template supports both the available 
+    [template keys](https://ayon.ynput.io/docs/admin_settings_project_anatomy#available-template-keys) 
+    and tokens defined in the `Clip Name Tokenizer`.
+    """
     enabled: bool = True
     shot_rename_template: str = SettingsField(
         "",
@@ -56,15 +64,23 @@ class TokenToParentConvertorItem(BaseSettingsModel):
 
 
 class ShotHierarchySubmodel(BaseSettingsModel):
+    """Shot Hierarchy Info
+
+    Shot Hierarchy defines the folder path where the shot will be added. 
+    It uses the `Folder path template` to compute this path. 
+    The `Folder path template` supports tokens defined in the `folder path template tokens` setting.
+
+    - Each token in the `Folder path template` represents a folder in the hierarchy.
+    - Each token can leverage tokens defined in the `Clip Name Tokenizer`.
+    """
     enabled: bool = True
     parents_path: str = SettingsField(
         "",
-        title="Parents path template",
-        description="Using keys from \"Token to parent convertor\" or tokens directly"  # noqa
+        title="Folder path template"
     )
     parents: list[TokenToParentConvertorItem] = SettingsField(
         default_factory=TokenToParentConvertorItem,
-        title="Token to parent convertor"
+        title="Folder path template tokens"
     )
 
 
@@ -94,12 +110,13 @@ class EditorialSimpleCreatorPlugin(BaseSettingsModel):
     )
     clip_name_tokenizer: list[ClipNameTokenizerItem] = SettingsField(
         default_factory=ClipNameTokenizerItem,
-        description=(
-            "Using Regex expression to create tokens. \nThose can be used"
-            " later in \"Shot rename\" creator \nor \"Shot hierarchy\"."
-            "\n\nTokens should be decorated with \"_\" on each side"
-        )
-    )
+        description="""Clip Name Tokenizer Info.
+
+                    Use Regex expression to create tokens.
+                    Those can be used  later in `Shot rename` creator or `Shot hierarchy`.
+                    Tokens should be enclosed by `_` on each side.
+                    """
+    )    
     shot_rename: ShotRenameSubmodel = SettingsField(
         title="Shot Rename",
         default_factory=ShotRenameSubmodel
@@ -110,7 +127,8 @@ class EditorialSimpleCreatorPlugin(BaseSettingsModel):
     )
     shot_add_tasks: list[ShotAddTasksItem] = SettingsField(
         title="Add tasks to shot",
-        default_factory=ShotAddTasksItem
+        default_factory=ShotAddTasksItem,
+        description="The following list of tasks will be added to each created shot."
     )
     product_type_presets: list[ProductTypePresetItem] = SettingsField(
         default_factory=list

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -13,7 +13,7 @@ class ClipNameTokenizerItem(BaseSettingsModel):
 
 class ShotAddTasksItem(BaseSettingsModel):
     _layout = "compact"
-    name: str = SettingsField('', title="Task Name")
+    name: str = SettingsField('', title="Task name")
     task_type: str = SettingsField(
         title="Task type",
         enum_resolver=task_types_enum
@@ -27,7 +27,7 @@ class ShotRenameSubmodel(BaseSettingsModel):
 
     The template supports both the available 
     [template keys](https://ayon.ynput.io/docs/admin_settings_project_anatomy#available-template-keys) 
-    and tokens defined in the `Clip Name Tokenizer`.
+    and tokens defined under `Clip Name Tokenizer`.
     """
     enabled: bool = True
     shot_rename_template: str = SettingsField(
@@ -50,7 +50,7 @@ class TokenToParentConvertorItem(BaseSettingsModel):
     name: str = SettingsField(
         "",
         title="Token name",
-        description="Unique name used in `Parent path template`"
+        description="Unique name used in `Folder path template tokens`"
     )
     value: str = SettingsField(
         "",
@@ -74,7 +74,7 @@ class ShotHierarchySubmodel(BaseSettingsModel):
     - Each token in the `Folder path template` represents a folder in the hierarchy.
     - Each token's value supports both the available 
     [template keys](https://ayon.ynput.io/docs/admin_settings_project_anatomy#available-template-keys) 
-    and tokens defined in the `Clip Name Tokenizer`.
+    and tokens defined under `Clip Name Tokenizer`.
     """
     enabled: bool = True
     parents_path: str = SettingsField(

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -67,8 +67,8 @@ class TokenToParentConvertorItem(BaseSettingsModel):
 class ShotHierarchySubmodel(BaseSettingsModel):
     """Shot Hierarchy Info
 
-    Shot Hierarchy defines the folder path where the shot will be added. 
-    It uses the `Folder path template` to compute this path. 
+    Shot Hierarchy defines the folder path where each shot will be added.
+    It uses the `Folder path template` to compute each path. 
     The `Folder path template` supports tokens defined in the `folder path template tokens` setting.
 
     - Each token in the `Folder path template` represents a folder in the hierarchy.


### PR DESCRIPTION
## Changelog Description
Follow up PR to https://github.com/ynput/ayon-traypublisher/pull/44 and https://github.com/ynput/ayon-traypublisher/pull/47

This PR is specifically for enhancing editorial creator settings
- It renames/rearranges some settings and adds description and docstrings.
![image](https://github.com/user-attachments/assets/567fc9fb-1dff-4c2a-aa70-fe4498d94e90)
- it also updates editorial creator attributes
![image](https://github.com/user-attachments/assets/6e75d6e2-0360-4301-a581-c8666d767a48)


## Testing notes:
1. Go through settings and validate if the changes enhances the UX of the settings.
2. This PR is backward compatible as it only change the settings' label, copy settings should work fine.
