### PR TITLE
Avoid setting up output name on source representation

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -191,6 +191,7 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
         source_filepaths.extend(filepaths)
         # First try to find out representation with same filepaths
         #   so it's not needed to create new representation just for review
+        use_source_as_review = False
         review_representation = None
         # Review path (only for logging)
         review_path = None
@@ -199,6 +200,7 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             if _filepaths == filepaths:
                 review_representation = representation
                 review_path = repre_path
+                use_source_as_review = True
                 break
 
         if review_representation is None:
@@ -219,7 +221,8 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
 
         # Adding "review" to representation name since it can clash with main
         # representation if they share the same extension.
-        review_representation["outputName"] = "review"
+        if not use_source_as_review:
+            review_representation["outputName"] = "review"
 
         self.log.debug("Representation {} was marked for review. {}".format(
             review_representation["name"], review_path


### PR DESCRIPTION
## Changelog Description
Key `outputName` is filled on representation only if is not re-used source representation for review.

## Additional review information
The output name affects how published file looks like which should not happen.

There might be other potential solution, and that would be to avoid using source representation and always create new one for review representation, don't know what it would meant.

## Testing notes:
1. Create package, upload to server and use in bundle.
2. Launch traypublisher.
3. Select project, folder and task.
4. Select `image` create plugin and drop a jpeg to both input and review file inputs.
5. Hit `Publish` and wait.
6. After successful publish look into integrated files, the source file should not end up with `_review.jpg` (which did happen before this PR).

Resolves https://github.com/ynput/ayon-traypublisher/issues/40