### PR TITLE
Chore: Process per project and webactions

### DIFF
--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -51,7 +51,7 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
         )
 
         cli_main.command(
-            self._ingest_csv,
+            self._cli_ingest_csv,
             name="ingestcsv",
         ).option(
             "--filepath",
@@ -124,7 +124,7 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
         )
         window.activateWindow()
 
-    def _ingest_csv(
+    def _cli_ingest_csv(
         self,
         filepath,
         project,

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -110,7 +110,7 @@ class TrayPublishAddon(
     def _cli_launch(self, project: Optional[str] = None):
         from .api.main import launch_traypublisher_ui
 
-        launch_traypublisher_ui(project)
+        launch_traypublisher_ui(self, project)
 
     def _start_traypublisher(self, project_name: str):
         args = get_ayon_launcher_args(

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -24,6 +24,8 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
     version = __version__
     host_name = "traypublisher"
 
+    _choose_dialog = None
+
     def tray_init(self):
         return
 

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -94,7 +94,9 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
         args = get_ayon_launcher_args(
             "addon", self.name, "launch", "--project", project_name
         )
-        run_detached_process(args)
+        env = os.environ.copy()
+        env["AYON_PROJECT_NAME"] = project_name
+        run_detached_process(args, env=env)
 
     def _get_choose_dialog(self):
         if self._choose_dialog is None:
@@ -112,6 +114,7 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
 
     def _show_choose_project(self):
         from qtpy import QtCore
+
         window = self._get_choose_dialog()
         window.show()
         window.setWindowState(

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -24,21 +24,11 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
     version = __version__
     host_name = "traypublisher"
 
-    def initialize(self, settings):
-        self.publish_paths = [
-            os.path.join(TRAYPUBLISH_ROOT_DIR, "plugins", "publish")
-        ]
-
     def tray_init(self):
         return
 
     def on_action_trigger(self):
         self.run_traypublisher()
-
-    def connect_with_addons(self, enabled_addons):
-        """Collect publish paths from other addons."""
-        publish_paths = self.manager.collect_plugin_paths()["publish"]
-        self.publish_paths.extend(publish_paths)
 
     def run_traypublisher(self):
         args = get_ayon_launcher_args(

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -11,6 +11,7 @@ from ayon_core.addon import (
     AYONAddon,
     ITrayAction,
     IHostAddon,
+    IPluginPaths,
 )
 
 from .version import __version__
@@ -18,7 +19,9 @@ from .version import __version__
 TRAYPUBLISH_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
+class TrayPublishAddon(
+    AYONAddon, IHostAddon, ITrayAction, IPluginPaths
+):
     label = "Publisher"
     name = "traypublisher"
     version = __version__
@@ -28,6 +31,25 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
 
     def tray_init(self):
         return
+
+    def get_plugin_paths(self):
+        return {}
+
+    def get_publish_plugin_paths(self, host_name):
+        output = []
+        if host_name == self.host_name:
+            output.append(
+                os.path.join(TRAYPUBLISH_ROOT_DIR, "plugins", "publish")
+            )
+        return output
+
+    def get_create_plugin_paths(self, host_name):
+        output = []
+        if host_name == self.host_name:
+            output.append(
+                os.path.join(TRAYPUBLISH_ROOT_DIR, "plugins", "create")
+            )
+        return output
 
     def on_action_trigger(self):
         self._show_choose_project()

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -1,6 +1,6 @@
 import os
-
 from pathlib import Path
+from typing import Optional
 
 import ayon_api
 
@@ -28,96 +28,104 @@ class TrayPublishAddon(AYONAddon, IHostAddon, ITrayAction):
         return
 
     def on_action_trigger(self):
-        self.run_traypublisher()
+        self._show_choose_project()
 
-    def run_traypublisher(self):
+    def cli(self, click_group):
+        cli_main = click_wrap.group(
+            self._cli_main,
+            name=self.name,
+            help="TrayPublisher commands"
+        )
+
+        cli_main.command(
+            self._cli_launch,
+            name="launch",
+            help="Launch TrayPublish tool UI.",
+        ).option(
+            "--project",
+            help="Project name",
+            envvar="AYON_PROJECT_NAME",
+            default=None,
+        )
+
+        cli_main.command(
+            self._ingest_csv,
+            name="ingestcsv",
+        ).option(
+            "--filepath",
+            help="Full path to CSV file with data",
+            type=str,
+            required=True
+        ).option(
+            "--project",
+            help="Project name in which the context will be used",
+            type=str,
+            required=True
+        ).option(
+            "--folder-path",
+            help="Asset name in which the context will be used",
+            type=str,
+            required=True
+        ).option(
+            "--task",
+            help="Task name under Asset in which the context will be used",
+            type=str,
+            required=False
+        ).option(
+            "--ignore-validators",
+            help="Option to ignore validators",
+            type=bool,
+            is_flag=True,
+            required=False
+        )
+        click_group.add_command(cli_main.to_click_obj())
+
+    def _cli_main(self):
+        pass
+
+    def _cli_launch(self, project: Optional[str] = None):
+        pass
+
+    def _start_traypublisher(self, project_name: str):
         args = get_ayon_launcher_args(
-            "addon", self.name, "launch"
+            "addon", self.name, "launch", "--project", project_name
         )
         run_detached_process(args)
 
-    def cli(self, click_group):
-        click_group.add_command(cli_main.to_click_obj())
+    def _show_choose_project(self):
+        pass
 
-
-@click_wrap.group(
-    TrayPublishAddon.name,
-    help="TrayPublisher related commands.")
-def cli_main():
-    pass
-
-
-@cli_main.command()
-def launch():
-    """Launch TrayPublish tool UI."""
-
-    from ayon_traypublisher import ui
-
-    ui.main()
-
-
-@cli_main.command()
-@click_wrap.option(
-    "--filepath",
-    help="Full path to CSV file with data",
-    type=str,
-    required=True
-)
-@click_wrap.option(
-    "--project",
-    help="Project name in which the context will be used",
-    type=str,
-    required=True
-)
-@click_wrap.option(
-    "--folder-path",
-    help="Asset name in which the context will be used",
-    type=str,
-    required=True
-)
-@click_wrap.option(
-    "--task",
-    help="Task name under Asset in which the context will be used",
-    type=str,
-    required=False
-)
-@click_wrap.option(
-    "--ignore-validators",
-    help="Option to ignore validators",
-    type=bool,
-    is_flag=True,
-    required=False
-)
-def ingestcsv(
-    filepath,
-    project,
-    folder_path,
-    task,
-    ignore_validators
-):
-    """Ingest CSV file into project.
-
-    This command will ingest CSV file into project. CSV file must be in
-    specific format. See documentation for more information.
-    """
-    from .csv_publish import csvpublish
-
-    # Allow user override through AYON_USERNAME when
-    # current connection is made through a service user.
-    username = os.environ.get("AYON_USERNAME")
-    if username:
-        con = ayon_api.get_server_api_connection()
-        if con.is_service_user():
-            con.set_default_service_username(username)
-
-    # use Path to check if csv_filepath exists
-    if not Path(filepath).exists():
-        raise FileNotFoundError(f"File {filepath} does not exist.")
-
-    csvpublish(
+    def _ingest_csv(
+        self,
         filepath,
         project,
         folder_path,
         task,
-        ignore_validators
-    )
+        ignore_validators,
+    ):
+        """Ingest CSV file into project.
+
+        This command will ingest CSV file into project. CSV file must be in
+        specific format. See documentation for more information.
+        """
+        from .csv_publish import csvpublish
+
+        # Allow user override through AYON_USERNAME when
+        # current connection is made through a service user.
+        username = os.environ.get("AYON_USERNAME")
+        if username:
+            con = ayon_api.get_server_api_connection()
+            if con.is_service_user():
+                con.set_default_service_username(username)
+
+        # use Path to check if csv_filepath exists
+        if not Path(filepath).exists():
+            raise FileNotFoundError(f"File {filepath} does not exist.")
+
+        csvpublish(
+            filepath,
+            project,
+            folder_path,
+            task,
+            ignore_validators
+        )

--- a/client/ayon_traypublisher/api/main.py
+++ b/client/ayon_traypublisher/api/main.py
@@ -1,0 +1,75 @@
+import os
+from typing import Optional
+
+from qtpy import QtWidgets, QtCore
+
+from ayon_core.pipeline import install_host
+from ayon_core.tools.utils import get_ayon_qt_app
+# from ayon_core.tools.utils.host_tools import show_publisher
+
+from ayon_traypublisher.ui import ChooseProjectWindow
+
+from .pipeline import TrayPublisherHost
+
+
+class _LaunchContext:
+    def __init__(
+        self,
+        app: QtWidgets.QApplication,
+        project_name: Optional[str],
+    ):
+        init_timer = QtCore.QTimer()
+
+        init_timer.timeout.connect(self._on_timer)
+
+        self._project_name = project_name
+        self._app = app
+        self._init_timer = init_timer
+        self._publisher_window = None
+
+    def start(self):
+        self._init_timer.start()
+
+    def _on_timer(self):
+        self._init_timer.stop()
+
+        if not self._project_name:
+            window = ChooseProjectWindow()
+            window.exec_()
+            self._project_name = window.get_selected_project_name()
+
+        if not self._project_name:
+            self.log.info("Project is not selected, exiting.")
+            self._app.exit(0)
+            return
+
+        os.environ["AYON_PROJECT_NAME"] = self._project_name
+        host = TrayPublisherHost()
+        install_host(host)
+
+        self._show_publisher()
+
+    def _show_publisher(self):
+        """Reimplement 'show_publisher' function from host tools.
+
+        The function in ayon-core has a bug that validates if host does match
+            ILoadHost interface, which is not the case for TrayPublisherHost.
+            It should be changed to validate IPublishHost interface instead.
+
+        Make sure ayon-core minimum required version is to the one where it is
+            fixed when this function is removed.
+
+        """
+        from ayon_core.tools.publisher.window import PublisherWindow
+
+        window = PublisherWindow()
+        window.make_sure_is_visible()
+        # Store the window to keep it in memory
+        self._publisher_window = window
+
+
+def launch_traypublisher_ui(project_name: Optional[str]):
+    app_instance = get_ayon_qt_app()
+    context = _LaunchContext(app_instance, project_name)
+    context.start()
+    app_instance.exec_()

--- a/client/ayon_traypublisher/api/main.py
+++ b/client/ayon_traypublisher/api/main.py
@@ -39,7 +39,7 @@ class _LaunchContext:
             self._project_name = window.get_selected_project_name()
 
         if not self._project_name:
-            self.log.info("Project is not selected, exiting.")
+            print("Project is not selected, exiting.")
             self._app.exit(0)
             return
 

--- a/client/ayon_traypublisher/api/pipeline.py
+++ b/client/ayon_traypublisher/api/pipeline.py
@@ -29,7 +29,7 @@ class TrayPublisherHost(HostBase, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
     def get_context_title(self):
-        return HostContext.get_project_name()
+        return self.get_current_project_name()
 
     def get_context_data(self):
         return HostContext.get_context_data()
@@ -41,7 +41,6 @@ class TrayPublisherHost(HostBase, IPublishHost):
         # TODO Deregister project specific plugins and register new project
         #   plugins
         os.environ["AYON_PROJECT_NAME"] = project_name
-        HostContext.set_project_name(project_name)
 
 
 class HostContext:
@@ -112,22 +111,6 @@ class HostContext:
     @classmethod
     def save_context_data(cls, data):
         cls._save_data("context", data)
-
-    @classmethod
-    def get_project_name(cls):
-        return cls._get_data("project_name")
-
-    @classmethod
-    def set_project_name(cls, project_name):
-        cls._save_data("project_name", project_name)
-
-    @classmethod
-    def get_data_to_store(cls):
-        return {
-            "project_name": cls.get_project_name(),
-            "instances": cls.get_instances(),
-            "context": cls.get_context_data(),
-        }
 
 
 def list_instances():

--- a/client/ayon_traypublisher/api/pipeline.py
+++ b/client/ayon_traypublisher/api/pipeline.py
@@ -2,6 +2,7 @@ import os
 import json
 import tempfile
 import atexit
+import warnings
 
 import pyblish.api
 
@@ -37,9 +38,23 @@ class TrayPublisherHost(HostBase, IPublishHost):
     def update_context_data(self, data, changes):
         HostContext.save_context_data(data)
 
-    def set_project_name(self, project_name):
-        # TODO Deregister project specific plugins and register new project
-        #   plugins
+    def set_project_name(self, project_name: str):
+        """Change project name.
+
+        DEPRECATED:
+            TrayPublisher now expects that project name is set before
+                is started, and is not possible to change project during
+                process lifetime.
+
+        """
+        warnings.warn(
+            (
+                "'set_project_name' is deprecated and will be removed"
+                " in future versions of TrayPublisher addon."
+                " Project name should be set before TrayPublisher is started."
+            ),
+            DeprecationWarning,
+        )
         os.environ["AYON_PROJECT_NAME"] = project_name
 
 

--- a/client/ayon_traypublisher/api/pipeline.py
+++ b/client/ayon_traypublisher/api/pipeline.py
@@ -6,17 +6,7 @@ import warnings
 
 import pyblish.api
 
-from ayon_core.pipeline import (
-    register_creator_plugin_path,
-)
 from ayon_core.host import HostBase, IPublishHost
-
-
-ROOT_DIR = os.path.dirname(os.path.dirname(
-    os.path.abspath(__file__)
-))
-PUBLISH_PATH = os.path.join(ROOT_DIR, "plugins", "publish")
-CREATE_PATH = os.path.join(ROOT_DIR, "plugins", "create")
 
 
 class TrayPublisherHost(HostBase, IPublishHost):
@@ -26,8 +16,6 @@ class TrayPublisherHost(HostBase, IPublishHost):
         os.environ["AYON_HOST_NAME"] = self.name
 
         pyblish.api.register_host("traypublisher")
-        pyblish.api.register_plugin_path(PUBLISH_PATH)
-        register_creator_plugin_path(CREATE_PATH)
 
     def get_context_title(self):
         return self.get_current_project_name()

--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -1,7 +1,8 @@
+import os
+
 import pyblish.api
 import pyblish.util
 
-from ayon_api import get_folder_by_path, get_task_by_name
 from ayon_core.lib.attribute_definitions import FileDefItem
 from ayon_core.pipeline import install_host
 from ayon_core.pipeline.create import CreateContext
@@ -24,14 +25,13 @@ def csvpublish(
         folder_path (str): Folder path.
         task_name (Optional[str]): Task name.
         ignore_validators (Optional[bool]): Option to ignore validators.
+
     """
+    os.environ["AYON_PROJECT_NAME"] = project_name
 
     # initialization of host
     host = TrayPublisherHost()
     install_host(host)
-
-    # setting host context into project
-    host.set_project_name(project_name)
 
     # form precreate data with field values
     file_field = FileDefItem.from_paths([filepath], False).pop().to_dict()

--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -2,6 +2,7 @@ import os
 
 import pyblish.api
 import pyblish.util
+from ayon_api import get_folder_by_path, get_task_by_name
 
 from ayon_core.lib.attribute_definitions import FileDefItem
 from ayon_core.pipeline import install_host

--- a/client/ayon_traypublisher/ui/__init__.py
+++ b/client/ayon_traypublisher/ui/__init__.py
@@ -1,6 +1,6 @@
-from .window import main
+from .window import ChooseProjectWindow
 
 
 __all__ = (
-    "main",
+    "ChooseProjectWindow",
 )

--- a/client/ayon_traypublisher/ui/window.py
+++ b/client/ayon_traypublisher/ui/window.py
@@ -5,59 +5,72 @@ Adds ability to select project using overlay widget with list of projects.
 Tray publisher can be considered as host implementeation with creators and
 publishing plugins.
 """
+from typing import Optional
 
-import platform
-
-from qtpy import QtWidgets, QtCore
+from qtpy import QtWidgets, QtCore, QtGui
 import qtawesome
 
-from ayon_core.lib import AYONSettingsRegistry, is_running_from_build
-from ayon_core.pipeline import install_host
-from ayon_core.tools.publisher.control_qt import QtPublisherController
-from ayon_core.tools.publisher.window import PublisherWindow
+from ayon_core.style import load_stylesheet
+from ayon_core.resources import get_ayon_icon_filepath
+from ayon_core.lib import AYONSettingsRegistry
+from ayon_core.lib.events import QueuedEventSystem
 from ayon_core.tools.common_models import ProjectsModel
 from ayon_core.tools.utils import (
     PlaceholderLineEdit,
-    get_ayon_qt_app,
     ProjectsQtModel,
     ProjectSortFilterProxy,
     PROJECT_NAME_ROLE,
 )
-from ayon_traypublisher.api import TrayPublisherHost
 
 
 class TrayPublisherRegistry(AYONSettingsRegistry):
     def __init__(self):
-        super(TrayPublisherRegistry, self).__init__("traypublisher")
+        super().__init__("traypublisher")
 
 
-class TrayPublisherController(QtPublisherController):
-    def __init__(self, *args, **kwargs):
-        super(TrayPublisherController, self).__init__(*args, **kwargs)
+class ChooseProjectController:
+    def __init__(self):
+        self._event_system = QueuedEventSystem()
         self._projects_model = ProjectsModel(self)
-
-    @property
-    def host(self):
-        return self._host
-
-    def reset_hierarchy_cache(self):
-        self._hierarchy_model.reset()
+        self._registry = AYONSettingsRegistry("traypublisher")
 
     def get_project_items(self, sender=None):
         return self._projects_model.get_project_items(sender)
 
+    def emit_event(self, topic, data=None, source=None):
+        """Use implemented event system to trigger event."""
 
-class StandaloneOverlayWidget(QtWidgets.QFrame):
-    project_selected = QtCore.Signal(str)
+        if data is None:
+            data = {}
+        self._event_system.emit(topic, data, source)
 
-    def __init__(self, controller, publisher_window):
-        super(StandaloneOverlayWidget, self).__init__(publisher_window)
-        self.setObjectName("OverlayFrame")
+    def register_event_callback(self, topic, callback):
+        self._event_system.add_callback(topic, callback)
 
-        middle_frame = QtWidgets.QFrame(self)
-        middle_frame.setObjectName("ChooseProjectFrame")
+    def get_last_user_project_name(self) -> Optional[str]:
+        try:
+            return self._registry.get_item("project_name")
+        except ValueError:
+            pass
 
-        content_widget = QtWidgets.QWidget(middle_frame)
+    def set_last_user_project_name(self, project_name: str):
+        self._registry.set_item("project_name", project_name)
+
+
+class ChooseProjectWindow(QtWidgets.QDialog):
+    default_width = 400
+    default_height = 600
+
+    def __init__(self, controller=None):
+        super().__init__()
+
+        self.setWindowTitle("Choose project for Tray Publisher")
+        self.setWindowIcon(QtGui.QIcon(get_ayon_icon_filepath()))
+
+        if controller is None:
+            controller = ChooseProjectController()
+
+        content_widget = QtWidgets.QWidget(self)
 
         header_label = QtWidgets.QLabel("Choose project", content_widget)
         header_label.setObjectName("ChooseProjectLabel")
@@ -74,10 +87,13 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
             QtWidgets.QAbstractItemView.NoEditTriggers
         )
 
-        confirm_btn = QtWidgets.QPushButton("Confirm", content_widget)
-        cancel_btn = QtWidgets.QPushButton("Cancel", content_widget)
-        cancel_btn.setVisible(False)
-        btns_layout = QtWidgets.QHBoxLayout()
+        btns_widget = QtWidgets.QWidget(content_widget)
+
+        confirm_btn = QtWidgets.QPushButton("Confirm", btns_widget)
+        cancel_btn = QtWidgets.QPushButton("Cancel", btns_widget)
+
+        btns_layout = QtWidgets.QHBoxLayout(btns_widget)
+        btns_layout.setContentsMargins(0, 0, 0, 0)
         btns_layout.addStretch(1)
         btns_layout.addWidget(cancel_btn, 0)
         btns_layout.addWidget(confirm_btn, 0)
@@ -85,8 +101,10 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
         txt_filter = PlaceholderLineEdit(content_widget)
         txt_filter.setPlaceholderText("Quick filter projects..")
         txt_filter.setClearButtonEnabled(True)
-        txt_filter.addAction(qtawesome.icon("fa.filter", color="gray"),
-                             QtWidgets.QLineEdit.LeadingPosition)
+        txt_filter.addAction(
+            qtawesome.icon("fa.filter", color="gray"),
+            QtWidgets.QLineEdit.LeadingPosition
+        )
 
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.setContentsMargins(0, 0, 0, 0)
@@ -94,17 +112,11 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
         content_layout.addWidget(header_label, 0)
         content_layout.addWidget(txt_filter, 0)
         content_layout.addWidget(projects_view, 1)
-        content_layout.addLayout(btns_layout, 0)
+        content_layout.addWidget(btns_widget, 0)
 
-        middle_layout = QtWidgets.QHBoxLayout(middle_frame)
-        middle_layout.setContentsMargins(30, 30, 10, 10)
-        middle_layout.addWidget(content_widget)
-
-        main_layout = QtWidgets.QHBoxLayout(self)
+        main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.setContentsMargins(10, 10, 10, 10)
-        main_layout.addStretch(1)
-        main_layout.addWidget(middle_frame, 2)
-        main_layout.addStretch(1)
+        main_layout.addWidget(content_widget, 1)
 
         projects_view.doubleClicked.connect(self._on_double_click)
         confirm_btn.clicked.connect(self._on_confirm_click)
@@ -118,154 +130,64 @@ class StandaloneOverlayWidget(QtWidgets.QFrame):
         self._confirm_btn = confirm_btn
         self._txt_filter = txt_filter
 
-        self._publisher_window = publisher_window
+        self._controller = controller
         self._project_name = None
+        self._first_show = True
+
+    def get_selected_project_name(self) -> Optional[str]:
+        return self._project_name
 
     def showEvent(self, event):
+        if self._first_show:
+            self.resize(self.default_width, self.default_height)
+        super().showEvent(event)
+        if self._first_show:
+            self._first_show = False
+            self.setStyleSheet(load_stylesheet())
+        self._refresh_projects()
+
+    def _refresh_projects(self):
         self._projects_model.refresh()
         # Sort projects after refresh
         self._projects_proxy.sort(0)
 
-        setting_registry = TrayPublisherRegistry()
-        try:
-            project_name = setting_registry.get_item("project_name")
-        except ValueError:
-            project_name = None
+        project_name = self._controller.get_last_user_project_name()
+        if not project_name:
+            return
 
-        if project_name:
-            src_index = self._projects_model.get_index_by_project_name(
-                project_name
+        src_index = self._projects_model.get_index_by_project_name(
+            project_name
+        )
+        index = self._projects_proxy.mapFromSource(src_index)
+        if index.isValid():
+            selection_model = self._projects_view.selectionModel()
+            selection_model.select(
+                index,
+                QtCore.QItemSelectionModel.SelectCurrent
             )
-            index = self._projects_proxy.mapFromSource(src_index)
-            if index.isValid():
-                selection_model = self._projects_view.selectionModel()
-                selection_model.select(
-                    index,
-                    QtCore.QItemSelectionModel.SelectCurrent
-                )
-                self._projects_view.setCurrentIndex(index)
-
-        self._cancel_btn.setVisible(self._project_name is not None)
-        super(StandaloneOverlayWidget, self).showEvent(event)
+            self._projects_view.setCurrentIndex(index)
 
     def _on_double_click(self):
-        self.set_selected_project()
+        self._set_selected_project()
 
     def _on_confirm_click(self):
-        self.set_selected_project()
+        self._set_selected_project()
 
     def _on_cancel_click(self):
-        self._set_project(self._project_name)
+        self.reject()
 
     def _on_text_changed(self):
         self._projects_proxy.setFilterRegularExpression(
             self._txt_filter.text())
 
-    def set_selected_project(self):
+    def _set_selected_project(self):
         index = self._projects_view.currentIndex()
 
         project_name = index.data(PROJECT_NAME_ROLE)
-        if project_name:
-            self._set_project(project_name)
+        if not project_name:
+            return
 
-    @property
-    def host(self):
-        return self._publisher_window.controller.host
+        self._controller.set_last_user_project_name(project_name)
 
-    def _set_project(self, project_name):
         self._project_name = project_name
-        self.host.set_project_name(project_name)
-        self.setVisible(False)
-        self.project_selected.emit(project_name)
-
-        setting_registry = TrayPublisherRegistry()
-        setting_registry.set_item("project_name", project_name)
-
-
-class TrayPublishWindow(PublisherWindow):
-    def __init__(self, *args, **kwargs):
-        controller = TrayPublisherController()
-        super(TrayPublishWindow, self).__init__(
-            controller=controller, reset_on_show=False
-        )
-
-        flags = self.windowFlags()
-        # Disable always on top hint
-        if flags & QtCore.Qt.WindowStaysOnTopHint:
-            flags ^= QtCore.Qt.WindowStaysOnTopHint
-
-        self.setWindowFlags(flags)
-
-        overlay_widget = StandaloneOverlayWidget(controller, self)
-
-        btns_widget = self._header_extra_widget
-
-        back_to_overlay_btn = QtWidgets.QPushButton(
-            "Change project", btns_widget
-        )
-        save_btn = QtWidgets.QPushButton("Save", btns_widget)
-        # TODO implement save mechanism of tray publisher
-        save_btn.setVisible(False)
-
-        btns_layout = QtWidgets.QHBoxLayout(btns_widget)
-        btns_layout.setContentsMargins(0, 0, 0, 0)
-
-        btns_layout.addWidget(save_btn, 0)
-        btns_layout.addWidget(back_to_overlay_btn, 0)
-
-        overlay_widget.project_selected.connect(self._on_project_select)
-        back_to_overlay_btn.clicked.connect(self._on_back_to_overlay)
-        save_btn.clicked.connect(self._on_tray_publish_save)
-
-        self._back_to_overlay_btn = back_to_overlay_btn
-        self._overlay_widget = overlay_widget
-
-    def _set_publish_frame_visible(self, publish_frame_visible):
-        super(TrayPublishWindow, self)._set_publish_frame_visible(
-            publish_frame_visible
-        )
-        self._back_to_overlay_btn.setVisible(not publish_frame_visible)
-
-    def _on_back_to_overlay(self):
-        self._overlay_widget.setVisible(True)
-        self._resize_overlay()
-
-    def _resize_overlay(self):
-        self._overlay_widget.resize(
-            self.width(),
-            self.height()
-        )
-
-    def resizeEvent(self, event):
-        super(TrayPublishWindow, self).resizeEvent(event)
-        self._resize_overlay()
-
-    def _on_project_select(self, project_name):
-        # TODO register project specific plugin paths
-        self._controller.save_changes(False)
-        self._controller.reset_hierarchy_cache()
-
-        self.reset()
-        if not self._controller.instances:
-            self._go_to_create_tab()
-
-    def _on_tray_publish_save(self):
-        self._controller.save_changes()
-        print("NOT YET IMPLEMENTED")
-
-
-def main():
-    host = TrayPublisherHost()
-    install_host(host)
-
-    app_instance = get_ayon_qt_app()
-
-    if not is_running_from_build() and platform.system().lower() == "windows":
-        import ctypes
-        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
-            u"traypublisher"
-        )
-
-    window = TrayPublishWindow()
-    window.show()
-    app_instance.exec_()
+        self.accept()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,5 @@
 from ayon_server.addons import BaseServerAddon
+from ayon_server.actions import SimpleActionManifest
 
 from .settings import TraypublisherSettings, DEFAULT_TRAYPUBLISHER_SETTING
 
@@ -9,3 +10,56 @@ class Traypublisher(BaseServerAddon):
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_TRAYPUBLISHER_SETTING)
+
+    async def get_simple_actions(
+        self,
+        project_name: str | None = None,
+        variant: str = "production",
+    ) -> list["SimpleActionManifest"]:
+        if not project_name:
+            return []
+        icon = {
+            "type": "material-symbols",
+            "name": "upload_2",
+            "color": "#ffffff",
+        }
+        kwargs = {
+            "label": "Tray Publisher",
+            "category": "Desktop tools",
+            "icon": icon,
+            "order": 100,
+            "entity_subtypes": None,
+            "allow_multiselection": False,
+        }
+        return [
+            SimpleActionManifest(
+                identifier="traypublisher.project",
+                entity_type="project",
+                **kwargs
+            ),
+            SimpleActionManifest(
+                identifier="traypublisher.folder",
+                entity_type="folder",
+                **kwargs
+            ),
+            SimpleActionManifest(
+                identifier="traypublisher.task",
+                entity_type="task",
+                **kwargs
+            ),
+        ]
+
+    async def execute_action(
+        self,
+        executor: "ActionExecutor",
+    ) -> "ExecuteResponseModel":
+        """Execute an action provided by the addon"""
+        context = executor.context
+        project_name = context.project_name
+
+        return await executor.get_launcher_action_response(
+            args=[
+                "addon", "traypublisher",
+                "launch", "--project", project_name,
+            ]
+        )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,7 +1,16 @@
+import typing
+
 from ayon_server.addons import BaseServerAddon
 from ayon_server.actions import SimpleActionManifest
 
 from .settings import TraypublisherSettings, DEFAULT_TRAYPUBLISHER_SETTING
+
+if typing.TYPE_CHECKING:
+    from ayon_server.actions import (
+        ActionExecutor,
+        ExecuteResponseModel,
+        SimpleActionManifest,
+    )
 
 
 class Traypublisher(BaseServerAddon):


### PR DESCRIPTION
## Changelog Description
Tray Publisher now runs in a context of a project that cannot be changed once launched. And adde option to start traypublisher using webactions.

## Additional review information
Being able to change project during lifetime of a host process has few problems. But main reason why we changed the behavior is preparation for per project bundle (still will need some changes in future, just preparation).

## Testing notes:
1. Create package, upload to server, use in bundle. Production or dev bundle, staging does not have option to show webactions.
2. In AYON web UI should be publish action on project, folder and task, that will start traypublisher.
3. When using `Publisher` action in tray, it does ask for project selection before starting traypublisher.
4. Publishing from traypublisher works the same way as before.

Resolves https://github.com/ynput/ayon-traypublisher/issues/65