### PR TITLE
Ingest CSV: Use create context functions to get entities

### DIFF
--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -1,7 +1,6 @@
 import pyblish.api
 import pyblish.util
 
-from ayon_api import get_folder_by_path, get_task_by_name
 from ayon_core.lib.attribute_definitions import FileDefItem
 from ayon_core.pipeline import install_host
 from ayon_core.pipeline.create import CreateContext
@@ -41,10 +40,7 @@ def csvpublish(
 
     # create context initialization
     create_context = CreateContext(host, headless=True)
-    folder_entity = get_folder_by_path(
-        project_name,
-        folder_path=folder_path,
-    )
+    folder_entity = create_context.get_folder_entity(folder_path)
 
     if not folder_entity:
         ValueError(
@@ -52,9 +48,8 @@ def csvpublish(
             f"exists at project '{project_name}'."
         )
 
-    task_entity = get_task_by_name(
-        project_name,
-        folder_entity["id"],
+    task_entity = create_context.get_task_entity(
+        folder_path,
         task_name,
     )
 


### PR DESCRIPTION
## Changelog Description
Use helper methods to fetch entities instead of using ayon api in Ingest CSV.

## Additional review information
The helper methods are using cache which might make the logic faster.

## Testing notes:
1. CSV ingerst still works as before.
