### PR TITLE
AY-7437 Make create_colorspace_look able to handle multiple chained files.

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
+++ b/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
@@ -18,6 +18,9 @@ from ayon_core.pipeline import colorspace
 from ayon_traypublisher.api.plugin import TrayPublishCreator
 
 
+LUT_KEY_PREFIX = "abs_lut_path"
+
+
 class CreateColorspaceLook(TrayPublishCreator):
     """Creates colorspace look files."""
 
@@ -45,14 +48,9 @@ This creator publishes color space look file (LUT).
         return "mdi.format-color-fill"
 
     def create(self, product_name, instance_data, pre_create_data):
-        repr_file = pre_create_data.get("luts_file")
-        if not repr_file:
+        repr_files = pre_create_data.get("luts_file")
+        if not repr_files:
             raise CreatorError("No files specified")
-
-        files = repr_file.get("filenames")
-        if not files:
-            # this should never happen
-            raise CreatorError("Missing files from representation")
 
         folder_path = instance_data["folderPath"]
         task_name = instance_data["task"]
@@ -72,10 +70,16 @@ This creator publishes color space look file (LUT).
             variant=instance_data["variant"],
         )
 
-        instance_data["creator_attributes"] = {
-            "abs_lut_path": (
-                Path(repr_file["directory"]) / files[0]).as_posix()
-        }
+        instance_data["creator_attributes"] = {}
+        for idx, repr_file in enumerate(repr_files):
+            files = repr_file.get("filenames")
+            if not files:
+                # this should never happen
+                raise CreatorError("Missing files from representation")
+
+            instance_data["creator_attributes"][f"{LUT_KEY_PREFIX}_{idx}"] = (
+                    (Path(repr_file["directory"]) / files[0]).as_posix()
+            )
 
         # Create new instance
         new_instance = CreatedInstance(self.product_type, product_name,
@@ -92,56 +96,71 @@ This creator publishes color space look file (LUT).
                 instance.transient_data["config_items"] = self.config_items
                 instance.transient_data["config_data"] = self.config_data
 
-    def get_instance_attr_defs(self):
-        return [
+    def get_attr_defs_for_instance(self, instance):
+        attrs = [
             EnumDef(
                 "working_colorspace",
                 self.colorspace_items,
                 default="Not set",
                 label="Working Colorspace",
             ),
-            UISeparatorDef(
-                label="Advanced1"
-            ),
-            TextDef(
-                "abs_lut_path",
-                label="LUT Path",
-            ),
-            EnumDef(
-                "input_colorspace",
-                self.colorspace_items,
-                default="Not set",
-                label="Input Colorspace",
-            ),
-            EnumDef(
-                "direction",
-                [
-                    (None, "Not set"),
-                    ("forward", "Forward"),
-                    ("inverse", "Inverse")
-                ],
-                default="Not set",
-                label="Direction"
-            ),
-            EnumDef(
-                "interpolation",
-                [
-                    (None, "Not set"),
-                    ("linear", "Linear"),
-                    ("tetrahedral", "Tetrahedral"),
-                    ("best", "Best"),
-                    ("nearest", "Nearest")
-                ],
-                default="Not set",
-                label="Interpolation"
-            ),
-            EnumDef(
-                "output_colorspace",
-                self.colorspace_items,
-                default="Not set",
-                label="Output Colorspace",
-            ),
         ]
+
+        # Collect all LUT files
+        all_files_url = (
+            key
+            for key in instance.data["creator_attributes"]
+            if key.startswith(LUT_KEY_PREFIX)
+        )
+
+        for idx, _ in enumerate(all_files_url):
+            lut_attrs = [
+                UISeparatorDef(
+                    f"separator_{idx}",
+                    label="Advanced1"
+                ),
+                TextDef(
+                    f"abs_lut_path_{idx}",
+                    label="LUT Path",
+                ),
+                EnumDef(
+                    f"input_colorspace_{idx}",
+                    self.colorspace_items,
+                    default="Not set",
+                    label="Input Colorspace",
+                ),
+                EnumDef(
+                    f"direction_{idx}",
+                    [
+                        (None, "Not set"),
+                        ("forward", "Forward"),
+                        ("inverse", "Inverse")
+                    ],
+                    default="Not set",
+                    label="Direction"
+                ),
+                EnumDef(
+                    f"interpolation_{idx}",
+                    [
+                        (None, "Not set"),
+                        ("linear", "Linear"),
+                        ("tetrahedral", "Tetrahedral"),
+                        ("best", "Best"),
+                        ("nearest", "Nearest")
+                    ],
+                    default="Not set",
+                    label="Interpolation"
+                ),
+                EnumDef(
+                    f"output_colorspace_{idx}",
+                    self.colorspace_items,
+                    default="Not set",
+                    label="Output Colorspace",
+                )
+            ]
+            attrs.extend(lut_attrs)
+
+        return attrs
 
     def get_pre_create_attr_defs(self):
         return [
@@ -150,8 +169,8 @@ This creator publishes color space look file (LUT).
                 folders=False,
                 extensions=self.extensions,
                 allow_sequences=False,
-                single_item=True,
-                label="Look Files",
+                single_item=False,
+                label="Look Up Table File(s)",
             )
         ]
 

--- a/client/ayon_traypublisher/plugins/publish/validate_colorspace_look.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_colorspace_look.py
@@ -33,7 +33,8 @@ class ValidateColorspaceLook(pyblish.api.InstancePlugin,
 
         for ociolook_item in ociolook_items:
             item_not_set_keys = self.validate_colorspace_set_attrs(
-                ociolook_item, creator_defs_by_key)
+                ociolook_item
+            )
             if item_not_set_keys:
                 not_set_keys[ociolook_item["name"]] = item_not_set_keys
 
@@ -57,7 +58,6 @@ class ValidateColorspaceLook(pyblish.api.InstancePlugin,
     def validate_colorspace_set_attrs(
         self,
         ociolook_item,
-        creator_defs_by_key
     ):
         """Validate colorspace look attributes"""
 
@@ -72,18 +72,10 @@ class ValidateColorspaceLook(pyblish.api.InstancePlugin,
 
         not_set_keys = []
         for key in check_keys:
-            if ociolook_item[key]:
+            if ociolook_item.get(key):
                 # key is set and it is correct
                 continue
 
-            def_label = creator_defs_by_key.get(key)
-
-            if not def_label:
-                # raise since key is not recognized by creator defs
-                raise KeyError(
-                    f"Colorspace look attribute '{key}' is not "
-                    f"recognized by creator attributes: {creator_defs_by_key}"
-                )
-            not_set_keys.append(def_label)
+            not_set_keys.append(key)
 
         return not_set_keys


### PR DESCRIPTION
## Changelog Description
Current `create_colorspace_look` can only published one LUT file at a time.
These changes enable publishing multiple "chained" LUT files to a single product.

## Additional review information

To keep current logic, the relevant colorspace look information is now asked per LUT file via dynamic `creator_attributes`.
E.g. for 2 Look Up Table files:
![image](https://github.com/user-attachments/assets/8b36e33a-9ac1-465d-a2b2-9eae24e735d8)


## Testing notes:
0. Ensure OCIO managed colorspace is enabled from your project (otherwise creator won't appear)
1. From the traypublisher, select `Colorspace Look`
2. Put one or multiple
3. Do not forget to fill up the colorspace additional data in the resulting product instance
4. Ensure publishing go through seemlessly
5. The result should integrate 1 json file with the serialized information + a backup of all of the relevant lut files.
6. (optional) test Nuke load through https://github.com/ynput/ayon-nuke/pull/77
