### PR TITLE
Fix publishing multiple representations with common extension (Image).

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -253,18 +253,24 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
         repre_name = repre_ext = ext[1:]
         if repre_name not in repre_names_counter:
             repre_names_counter[repre_name] = 2
+            counter = None
         else:
             counter = repre_names_counter[repre_name]
             repre_names_counter[repre_name] += 1
             repre_name = "{}_{}".format(repre_name, counter)
         repre_names.append(repre_name)
-        return {
+        representation_data = {
             "ext": repre_ext,
             "name": repre_name,
             "stagingDir": filepath_item["directory"],
             "files": filenames,
             "tags": []
         }
+
+        if counter:
+            representation_data["outputName"] = str(counter)
+
+        return representation_data
 
     def _calculate_source(self, filepaths):
         cols, rems = clique.assemble(filepaths)


### PR DESCRIPTION
## Changelog Description

Flagged on [Discord](https://discord.com/channels/517362899170230292/1339510322733781063/1341772287564714004).

Fixes this issue where attempting to publish multiple representation with similar extension fails:
```
DEBUG: Creating new version ...
DEBUG: Prepared version: v003
DEBUG: http://localhost:5000 "POST /graphql HTTP/1.1" 200 112
DEBUG: Response <RestApiResponse [200]>
DEBUG: Anatomy template name: default
DEBUG: Anatomy template name: default
Traceback (most recent call last):
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 158, in process
    self.register(instance, file_transactions, filtered_repres)
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 256, in register
    file_transactions.add(src, dst)
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\lib\file_transaction.py", line 97, in add
    raise DuplicateDestinationError(
ayon_core.lib.file_transaction.DuplicateDestinationError: Transfer to destination is already in queue: C:\Users\robin\Downloads\20230831_111612.jpg -> C:\projects\Dummy\shots\test_hiero_luts\from_tp\publish\image\imageConcept\v003\Dmmy_from_tp_imageConcept_v003.jpg. It's not allowed to be replaced by a new transfer from C:\Users\robin\Downloads\AY01_VFX_demo\AY01_VFX_demo\shots\sq001\sh040\publish\render\renderCompAnamorph\v001\_thumb\a01vfxd_sh040_renderCompAnamorph_v001_thumb.jpg

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\robin\AppData\Local\Ynput\AYON\dependency_packages\ayon_2406251801_windows.zip\dependencies\pyblish\plugin.py", line 528, in __explicit_process
    runner(*args)
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 163, in process
    raise KnownPublishError(exc).with_traceback(sys.exc_info()[2])
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 158, in process
    self.register(instance, file_transactions, filtered_repres)
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\plugins\publish\integrate.py", line 256, in register
    file_transactions.add(src, dst)
  File "C:\Users\robin\OneDrive\Bureau\dev_ayon\dev\ayon-core\client\ayon_core\lib\file_transaction.py", line 97, in add
    raise DuplicateDestinationError(
ayon_core.pipeline.publish.publish_plugins.KnownPublishError: Transfer to destination is already in queue: C:\Users\robin\Downloads\20230831_111612.jpg -> C:\projects\Dummy\shots\test_hiero_luts\from_tp\publish\image\imageConcept\v003\Dmmy_from_tp_imageConcept_v003.jpg. It's not allowed to be replaced by a new transfer from C:\Users\robin\Downloads\AY01_VFX_demo\AY01_VFX_demo\shots\sq001\sh040\publish\render\renderCompAnamorph\v001\_thumb\a01vfxd_sh040_renderCompAnamorph_v001_thumb.jpg
```

## Testing notes:
1. Try to publish an `image` through TrayPublisher
2. Set multiple files with a common extension in `Representations`
3. Ensure Publish go through properly