### PR TITLE
AY-7442 Add SXR support for plate, render and image simple publishers.

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import clique
 import pyblish.api
 
+from ayon_core.lib import transcoding
+from ayon_core.pipeline import PublishError
+
 
 class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
     """Collect data for instances created by settings creators.
@@ -83,6 +86,17 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             # - we should maybe not fill the key when sequence is used?
             origin_basename = Path(source_filepaths[0]).stem
             instance.data["originalBasename"] = origin_basename
+
+        # Special test for SXR format.
+        for repre in instance.data["representations"]:
+            if (
+                repre["ext"].lower() == "sxr"
+                and ".sxr" not in transcoding.IMAGE_EXTENSIONS
+            ):
+                raise PublishError(
+                    "SXR extension is not supported. Update"
+                    " ayon-core in order to fix this."
+                )
 
         self.log.debug(
             (

--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -88,6 +88,9 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
             instance.data["originalBasename"] = origin_basename
 
         # Special test for SXR format.
+        # The following code can be removed as soon as a new
+        # ayon-core dependency is set on ayon-traypublisher.
+        # https://github.com/ynput/ayon-traypublisher/issues/77
         for repre in instance.data["representations"]:
             if (
                 repre["ext"].lower() == "sxr"

--- a/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -24,7 +24,7 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
     # published data might be sequence (.mov, .mp4) in that counting files
     # doesn't make sense
     check_extensions = ["exr", "dpx", "jpg", "jpeg", "png", "tiff", "tga",
-                        "gif", "svg"]
+                        "gif", "svg", "sxr"]
     skip_timelines_check = []  # skip for specific task names (regex)
 
     def process(self, instance):

--- a/server/settings/simple_creators.py
+++ b/server/settings/simple_creators.py
@@ -141,6 +141,7 @@ DEFAULT_SIMPLE_CREATORS = [
         "allow_version_control": False,
         "extensions": [
             ".exr",
+            ".sxr",
             ".png",
             ".dng",
             ".dpx",
@@ -165,6 +166,7 @@ DEFAULT_SIMPLE_CREATORS = [
         "allow_version_control": False,
         "extensions": [
             ".exr",
+            ".sxr",
             ".png",
             ".dng",
             ".dpx",
@@ -215,6 +217,7 @@ DEFAULT_SIMPLE_CREATORS = [
         "allow_version_control": False,
         "extensions": [
             ".exr",
+            ".sxr",
             ".jpg",
             ".jpeg",
             ".dng",


### PR DESCRIPTION
## Changelog Description

resolve: https://github.com/ynput/ayon-nuke/issues/69

Changes:
* Add SXR image extension support for `plate`, `render` and `image` simple creators.
* Ensure SXR extension is properly validated by `validate_frame_range` plugin

## Additional review information

Needs to be tested with: https://github.com/ynput/ayon-core/pull/1165


## Testing notes:
1. Download this [SXR material](https://drive.google.com/drive/folders/1tl5JVaNIQdWbLfYBgtSHJiYUQ63X4SKy)
2. Publish this material as `image`, `render` or `plate` through the simple creators
3. Gather resulting material in Nuke as `image` and/or `clip`
