### PR TITLE
Add spm file as publishing format in tray publisher

### DIFF
--- a/server/settings/simple_creators.py
+++ b/server/settings/simple_creators.py
@@ -71,7 +71,8 @@ DEFAULT_SIMPLE_CREATORS = [
             ".drp",
             ".psd",
             ".psb",
-            ".aep"
+            ".aep",
+            ".spm",
         ]
     },
     {


### PR DESCRIPTION
## Changelog Description
Links to https://github.com/ynput/ayon-speedtree/pull/6
Implemented for external project files to be used in SpeedTree Modeler with AYON plugins

## Additional review information
n/a 

## Testing notes:
1. Build and install the addon
2. Publish
