### PR TITLE
AY-7395 Include resolution width and height in CSV ingest.

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -178,6 +178,7 @@ class ProductItem:
         task_type: Optional[str] = None,
         width: int = None,
         height: int = None,
+        pixel_aspect: float = None,
     ):
         self.folder_path = folder_path
         self.task_name = task_name
@@ -192,6 +193,7 @@ class ProductItem:
         self._pre_product_name = None
         self.width = width
         self.height = height
+        self.pixel_aspect = pixel_aspect
 
     @property
     def unique_name(self) -> str:
@@ -228,6 +230,7 @@ class ProductItem:
                 ("folder_path", "Folder Path"),
                 ("width", "Shot Width"),
                 ("height", "Shot Height"),
+                ("pixel_aspect", "Shot Pixel Aspect"),
                 ("task_name", "Task Name"),
                 ("version", "Version"),
                 ("variant", "Variant"),
@@ -961,6 +964,9 @@ configuration in project settings.
                         "heroTrack": True,
                     }
                 )
+
+                if product_item.pixel_aspect:
+                    instance_data["pixelAspect"] = product_item.pixel_aspect
 
                 if product_item.width and product_item.height:
                     instance_data.update(

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -387,6 +387,13 @@ DEFAULT_CREATORS = {
                     "required_column": False,
                     "validation_pattern": "^(\\d*)$"
                 },
+                {
+                    "name": "Shot Pixel Aspect",
+                    "type": "decimal",
+                    "default": "0",
+                    "required_column": False,
+                    "validation_pattern": "^(\\d*.?\\d*)$"
+                },
             ]
         },
         "representations_config": {

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -372,7 +372,21 @@ DEFAULT_CREATORS = {
                     "default": "",
                     "required_column": False,
                     "validation_pattern": "^(.*)$"
-                }
+                },
+                {
+                    "name": "Shot Height",
+                    "type": "number",
+                    "default": "0",
+                    "required_column": False,
+                    "validation_pattern": "^(\\d*)$"
+                },
+                {
+                    "name": "Shot Width",
+                    "type": "number",
+                    "default": "0",
+                    "required_column": False,
+                    "validation_pattern": "^(\\d*)$"
+                },
             ]
         },
         "representations_config": {


### PR DESCRIPTION
## Changelog Description

resolve: https://github.com/ynput/ayon-traypublisher/issues/62
Add optional column in CSV ingest so that shot width and height can be defined via `Shot Width` and `Shot Height` values in the CSV.

## Testing notes:

1.Create a new package and upload it to your AYON server
2.Prepare a CSV file with Folder Path that do not exist yet
3. Edit the CSV file with additional  `Shot Width` and `Shot Height` column and values
4.Ingest the CSV file through the publisher option in traypublisher
5.Ensure data is publish as expected and new shot(s) have been created with proper provided resolution
