### PR TITLE
Inject resolution attribute in collect_shot_instances.

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -153,35 +153,42 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
         handle_start = int(instance.data["handleStart"])
         handle_end = int(instance.data["handleEnd"])
 
-        in_info = {
-            "entity_type": "folder",
-            "folder_type": "Shot",
-            "attributes": {
-                "handleStart": handle_start,
-                "handleEnd": handle_end,
-                "frameStart": instance.data["frameStart"],
-                "frameEnd": instance.data["frameEnd"],
-                "clipIn": instance.data["clipIn"],
-                "clipOut": instance.data["clipOut"],
-                "fps": instance.data["fps"]
-            },
-            "tasks": instance.data["tasks"]
+        attributes = {
+            "handleStart": handle_start,
+            "handleEnd": handle_end,
+            "frameStart": instance.data["frameStart"],
+            "frameEnd": instance.data["frameEnd"],
+            "clipIn": instance.data["clipIn"],
+            "clipOut": instance.data["clipOut"],
+            "fps": instance.data["fps"]
         }
 
+        # resolutionWidth and resolutionHeight might not be defined,
+        # they are optional resolution values to create the shot with.
+        # When not provided, the shot inherit parent's values.
         if (
             instance.data.get("resolutionWidth")
             and instance.data.get("resolutionHeight")
         ):
 
-            in_info["attributes"].update(
+            attributes.update(
                 {
                     "resolutionWidth": instance.data["resolutionWidth"],
                     "resolutionHeight": instance.data["resolutionHeight"],
                 }
             )
 
+            # Same goes for shot pixel aspect ratio.
+            # When not explicitely provided, it defaults to square (1.0).
             if instance.data.get("pixelAspect"):
-                in_info["attributes"]["pixelAspect"] = instance.data["pixelAspect"]
+                attributes["pixelAspect"] = instance.data["pixelAspect"]
+
+        in_info = {
+            "entity_type": "folder",
+            "folder_type": "Shot",
+            "attributes": attributes,
+            "tasks": instance.data["tasks"]
+        }
 
         parents = instance.data.get('parents', [])
 

--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -179,7 +179,7 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
             )
 
             # Same goes for shot pixel aspect ratio.
-            # When not explicitely provided, it defaults to square (1.0).
+            # When not explicitly provided, it defaults to square (1.0).
             if instance.data.get("pixelAspect"):
                 attributes["pixelAspect"] = instance.data["pixelAspect"]
 

--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -168,6 +168,21 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
             "tasks": instance.data["tasks"]
         }
 
+        if (
+            instance.data.get("resolutionWidth")
+            and instance.data.get("resolutionHeight")
+        ):
+
+            in_info["attributes"].update(
+                {
+                    "resolutionWidth": instance.data["resolutionWidth"],
+                    "resolutionHeight": instance.data["resolutionHeight"],
+                }
+            )
+
+            if instance.data.get("pixelAspect"):
+                in_info["attributes"]["pixelAspect"] = instance.data["pixelAspect"]
+
         parents = instance.data.get('parents', [])
 
         folder_name = instance.data["folderPath"].split("/")[-1]


### PR DESCRIPTION
## Changelog Description

When reviewing https://github.com/ynput/ayon-core/pull/1255 I realize the provided use-case was not working properly because of missing resolution attribute in `collect_shot_instances`.

## Testing notes:
1. Run with tests described at https://github.com/ynput/ayon-core/pull/1255 
