### PR TITLE
Settings: Use 'conditional_enum'

### DIFF
--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -205,7 +205,7 @@ class ProductTypeAdvancedPresetItem(BaseSettingsModel):
             "From file - will use version from the file name if any found"
             "Locked - will use locked version number"
         ),
-        conditionalEnum=True,
+        conditional_enum=True,
     )
     locked: int = SettingsField(
         1,


### PR DESCRIPTION
## Changelog Description
Use `conditional_enum` instead of `conditionalEnum`.

## Testing notes:
1. Settings still do work.
