### PR TITLE
Chore: Use collected plugins in csv publish

### DIFF
--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -78,4 +78,8 @@ def csvpublish(
         targets = ["default", "ingest"]
 
     # publishing
-    pyblish.util.publish(context=pyblish_context, targets=targets)
+    pyblish.util.publish(
+        context=pyblish_context,
+        targets=targets,
+        plugins=create_context.publish_plugins,
+    )


### PR DESCRIPTION
## Changelog Description
CSV publish is passing discovered plugins from create context into pyblish utils.

## Testing notes:
1. CSV publish still does publish.
