### PR TITLE
AY-7790 Simple editorial: Add parenting of instances

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -132,6 +132,8 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
                 label="Linked to",
                 default=parent_instance,
                 disabled=True,
+                # Hide if parenting is available
+                visible=ParentFlags is None,
             )
         ]
 

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -24,6 +24,11 @@ from ayon_core.lib import (
     UISeparatorDef,
     UILabelDef
 )
+try:
+    from ayon_core.pipeline.create import ParentFlags
+except ImportError:
+    # Parenting was added with 'https://github.com/ynput/ayon-core/pull/1395'
+    ParentFlags = None
 
 
 CLIP_ATTR_DEFS = [
@@ -90,6 +95,17 @@ CLIP_ATTR_DEFS = [
 class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
     """Wrapper class for clip product type creators."""
     host_name = "traypublisher"
+
+    def _add_instance_to_context(self, instance):
+        parent_id = instance.get("parent_instance_id")
+        if parent_id is not None and ParentFlags is not None:
+            instance.set_parent(
+                parent_id,
+                # Disable if a parent is disabled and delete if a parent
+                #   is deleted
+                ParentFlags.share_active | ParentFlags.parent_lifetime
+            )
+        super()._add_instance_to_context(instance)
 
     def create(self, instance_data, source_data=None):
         product_name = instance_data["productName"]

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -125,15 +125,13 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
             BoolDef(
                 "add_review_family",
                 default=True,
-                label="Review"
+                label="Review",
             ),
             TextDef(
                 "parent_instance",
                 label="Linked to",
                 default=parent_instance,
                 disabled=True,
-                # Hide if parenting is available
-                visible=ParentFlags is None,
             )
         ]
 

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -119,7 +119,8 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
         return new_instance
 
-    def get_instance_attr_defs(self):
+    def get_attr_defs_for_instance(self, instance):
+        parent_instance = instance.creator_attributes.get("parent_instance")
         return [
             BoolDef(
                 "add_review_family",
@@ -129,8 +130,9 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
             TextDef(
                 "parent_instance",
                 label="Linked to",
-                disabled=True
-            ),
+                default=parent_instance,
+                disabled=True,
+            )
         ]
 
 


### PR DESCRIPTION
## Changelog Description
Use parenting advantage in simple editorial workflow to visualize tree of instances in publisher.

## Additional review information
Changes should be backwards compatible. Children instances are automatically removed if parent instance is removed and are automatically disabled if parent instance is disabled.

## Testing notes:
1. Use ayon-core with https://github.com/ynput/ayon-core/pull/1395 PR.
2. Simple editorial creation should work and should visualize the instances in hierarchy.
3. If a parent is removed then all children are removed too.
4. If a parent is disabled then all children are disabled too.
5. Test if the functionlity works with develop of ayon-core, it should work exactly as before this PR.