### PR TITLE
Fixing few Advanced Editorial bugs

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -1224,7 +1224,7 @@ or updating already created. Publishing will create OTIO file.
                 extensions=[".edl", ".xml", ".aaf", ".fcpxml"],
                 allow_sequences=False,
                 single_item=False,
-                label="Sequence file",
+                label="Edit Project Files",
             ),
             FileDef(
                 "folder_path_data",
@@ -1232,7 +1232,7 @@ or updating already created. Publishing will create OTIO file.
                 single_item=False,
                 extensions=[],
                 allow_sequences=False,
-                label="Folder path",
+                label="Media Source Folder",
             ),
             # TODO: perhaps better would be timecode and fps input
             NumberDef("timeline_offset", default=0, label="Timeline offset"),

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -1309,11 +1309,13 @@ def find_string_differences(files: List[str]) -> Dict[str, str]:
     # Find common prefix using zip_longest to compare all characters at once
     prefix = ""
     for chars in zip_longest(*processed_files):
-        # If there's more than one unique character
-        if len(set(chars) - {None}) != 1:
+        chars_s = set(chars)
+        # Ignore shorter filenames
+        chars_s.discard(None)
+        # End if a character in all filenames is not the same
+        if len(chars_s) != 1:
             break
-        if chars[0] is not None:  # Ensure we don't add None
-            prefix += chars[0]
+        prefix += next(iter(chars_s))
 
     # Find common suffix by reversing strings
     reversed_files = [f[::-1] for f in processed_files]

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -213,6 +213,15 @@ class EditorialModelInstanceCreator(EditorialClipInstanceCreatorBase):
     product_type = "model"
     label = "Model product"
 
+    def get_instance_attr_defs(self):
+        return [
+            TextDef(
+                "parent_instance",
+                label="Linked to",
+                disabled=True
+            ),
+        ]
+
 
 class EditorialCameraInstanceCreator(EditorialClipInstanceCreatorBase):
     """Camera product type class
@@ -222,6 +231,14 @@ class EditorialCameraInstanceCreator(EditorialClipInstanceCreatorBase):
     product_type = "camera"
     label = "Camera product"
 
+    def get_instance_attr_defs(self):
+        return [
+            TextDef(
+                "parent_instance",
+                label="Linked to",
+                disabled=True
+            ),
+        ]
 
 class EditorialWorkfileInstanceCreator(EditorialClipInstanceCreatorBase):
     """Workfile product type class
@@ -232,6 +249,14 @@ class EditorialWorkfileInstanceCreator(EditorialClipInstanceCreatorBase):
     product_type = "workfile"
     label = "Workfile product"
 
+    def get_instance_attr_defs(self):
+        return [
+            TextDef(
+                "parent_instance",
+                label="Linked to",
+                disabled=True
+            ),
+        ]
 
 class EditorialAdvancedCreator(TrayPublishCreator):
     """Advanced Editorial creator class
@@ -884,11 +909,15 @@ or updating already created. Publishing will create OTIO file.
                 "parent_instance_id": parenting_data["instance_id"],
                 "creator_attributes": {
                     "parent_instance": parenting_data["instance_label"],
-                    "add_review_family": reviewable,
                 },
                 "version": version,
                 "prep_representations": representations,
             })
+
+            if pres_product_type not in ["model", "workfile", "camera"]:
+                instance_data["creator_attributes"]["add_review_family"] = (
+                    reviewable
+                )
 
             creator_identifier = f"editorial_{pres_product_type}_advanced"
             editorial_clip_creator = self.create_context.creators[

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -321,7 +321,7 @@ or updating already created. Publishing will create OTIO file.
             folder_path
         )
 
-        if folder_entity and pre_create_data["fps"] == "from_selection":
+        if pre_create_data["fps"] == "from_selection":
             # get 'fps' from folder attributes
             fps = folder_entity["attrib"]["fps"]
         else:
@@ -973,7 +973,7 @@ or updating already created. Publishing will create OTIO file.
             product_name="shotMain",
         )
         instance_data["otioClip"] = otio.adapters.write_to_string(otio_clip)
-        c_instance = self.create_context.creators["editorial_shot"].create(
+        c_instance = self.create_context.creators["editorial_shot_advanced"].create(
             instance_data
         )
         parenting_data.update(

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -1280,9 +1280,11 @@ def find_string_differences(files: List[str]) -> Dict[str, str]:
     # Find common prefix using zip_longest to compare all characters at once
     prefix = ""
     for chars in zip_longest(*processed_files):
-        if len(set(chars) - {None}) != 1:  # If there's more than one unique character
+        # If there's more than one unique character
+        if len(set(chars) - {None}) != 1:
             break
-        prefix += chars[0]
+        if chars[0] is not None:  # Ensure we don't add None
+            prefix += chars[0]
 
     # Find common suffix by reversing strings
     reversed_files = [f[::-1] for f in processed_files]

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -30,7 +30,7 @@ CLIP_ATTR_DEFS = [
     EnumDef(
         "fps",
         items=[
-            {"value": "from_selection", "label": "From selection"},
+            {"value": "from_selection", "label": "From selected context"},
             {"value": 23.997, "label": "23.976"},
             {"value": 24, "label": "24"},
             {"value": 25, "label": "25"},
@@ -233,8 +233,8 @@ or updating already created. Publishing will create OTIO file.
         }
 
         folder_path = instance_data["folderPath"]
-        folder_entity = ayon_api.get_folder_by_path(
-            self.project_name, folder_path
+        folder_entity = self.create_context.get_folder_entity(
+            folder_path
         )
 
         if pre_create_data["fps"] == "from_selection":
@@ -243,9 +243,7 @@ or updating already created. Publishing will create OTIO file.
         else:
             fps = float(pre_create_data["fps"])
 
-        instance_data.update({
-            "fps": fps
-        })
+        instance_data["fps"] = fps
 
         # get path of sequence
         sequence_path_data = pre_create_data["sequence_filepath_data"]

--- a/client/ayon_traypublisher/plugins/publish/collect_editorial_reviewable.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_editorial_reviewable.py
@@ -18,7 +18,11 @@ class CollectEditorialReviewable(pyblish.api.InstancePlugin):
         if creator_identifier not in [
             "editorial_plate",
             "editorial_audio",
-            "editorial_review"
+            "editorial_review",
+            "editorial_audio_advanced",
+            "editorial_plate_advanced",
+            "editorial_image_advanced",
+            "editorial_render_advanced",
         ]:
             return
 
@@ -27,4 +31,6 @@ class CollectEditorialReviewable(pyblish.api.InstancePlugin):
         if creator_attributes["add_review_family"]:
             instance.data["families"].append("review")
 
-        self.log.debug("instance.data {}".format(instance.data))
+        self.log.info(
+            f"Collecting reviewable data for instance: {instance.name}"
+        )


### PR DESCRIPTION
## Changelog Description
Unblocking the issue with None type is not possible to add to string type. Also improving consistency of reviewable attribute to be only offered to image based products.

## Additional info
-  Enhances performance and reliability when handling file names with varying characters.
- Removed redundant checks and added a condition to avoid adding `None` values to the prefix.
- Passing instance reviewable attribute for proper reviewable files creation.

## Testing steps
1. Use advanced editorial data for testing https://drive.google.com/open?id=18rtOZsSoF2ENNVHxZOv7pBxMBtfLIzYV&usp=drive_fs
2. open publisher from tray and make sure your Advanced editorial creator is enabled `ayon+settings://traypublisher/editorial_creators/editorial_advanced`
3. add following settings from clipboard to the above mentioned category [settings_dump.txt](https://github.com/user-attachments/files/21602473/settings_dump.txt)
4. Reload Publisher after you change those settings
5. drop the files from testing data and hit create.
6. Publish - all should be looking fine.. 

  