### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -889,12 +889,12 @@ configuration in project settings.
             folder_path: str = product_item.folder_path
             version: int = product_item.version
             product_name: str = get_product_name(
-                project_name,
-                product_item.task_name,
-                product_item.task_type,
-                self.host_name,
-                product_item.product_type,
-                product_item.variant
+                project_name=project_name,
+                task_name=product_item.task_name,
+                task_type=product_item.task_type,
+                host_name=self.host_name,
+                product_type=product_item.product_type,
+                variant=product_item.variant,
             )
 
             if version is not None:

--- a/client/ayon_traypublisher/plugins/create/create_movie_batch.py
+++ b/client/ayon_traypublisher/plugins/create/create_movie_batch.py
@@ -122,12 +122,12 @@ class BatchMovieCreator(TrayPublishCreator):
             task_type = task_entity["taskType"]
         try:
             product_name = get_product_name(
-                project_name,
-                task_name,
-                task_type,
-                host_name,
-                self.product_type,
-                variant,
+                project_name=project_name,
+                task_name=task_name,
+                task_type=task_type,
+                host_name=host_name,
+                product_type=self.product_type,
+                variant=variant,
             )
         except TaskNotSetError:
             # Create instance with fake task
@@ -136,12 +136,12 @@ class BatchMovieCreator(TrayPublishCreator):
             # NOTE: This expect that there is not task 'Undefined' on folder
             dumb_value = "Undefined"
             product_name = get_product_name(
-                project_name,
-                dumb_value,
-                dumb_value,
-                host_name,
-                self.product_type,
-                variant,
+                project_name=project_name,
+                task_name=dumb_value,
+                task_type=dumb_value,
+                host_name=host_name,
+                product_type=self.product_type,
+                variant=variant,
             )
 
         return product_name

--- a/client/ayon_traypublisher/plugins/create/create_online.py
+++ b/client/ayon_traypublisher/plugins/create/create_online.py
@@ -108,7 +108,8 @@ class OnlineCreator(TrayPublishCreator):
         task_entity,
         variant,
         host_name=None,
-        instance=None
+        instance=None,
+        project_entity=None,
     ):
         if instance is None:
             return "{originalBasename}"


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
