### PR TITLE
Chore: Better launch handling

### DIFF
--- a/client/ayon_traypublisher/api/main.py
+++ b/client/ayon_traypublisher/api/main.py
@@ -45,12 +45,13 @@ class _LaunchContext:
         if not self._project_name:
             window = ChooseProjectWindow()
             window.exec_()
-            self._project_name = window.get_selected_project_name()
+            project_name = window.get_selected_project_name()
+            if not project_name:
+                print("Project is not selected, exiting.")
+                self._app.exit(0)
+                return
 
-        if not self._project_name:
-            print("Project is not selected, exiting.")
-            self._app.exit(1)
-            return
+            self._project_name = project_name
 
         project = ayon_api.get_project(self._project_name)
         if not project:


### PR DESCRIPTION
## Changelog Description
Validate project existence and use non zero exit code.

## Additional review information
Using 0 exit make it look like all went good. Validation of project existence will trigger error exit instead of "weird" message.

## Testing notes:
1. Try to run traypublisher using `addon traypublisher launch --project blabla`.
2. It should print that the project does not exists 
