### PR TITLE
Collect frame range and fps for video files

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -177,6 +177,16 @@ class CollectVideoData(pyblish.api.InstancePlugin):
     families = ["collect.video.framerange"]
 
     def process(self, instance):
+        if all(
+            key in instance.data 
+            for key in ("frameStart", "frameEnd", "fps")
+        ):
+            self.log.debug(
+                "Skipping video frame range collection because"
+                " instance already has frame range data."
+            )
+            return
+
         frame_data = self.get_frame_data_from_representations(instance)
         if not frame_data:
             return


### PR DESCRIPTION
## Changelog Description

Add Collector for video data, getting the frame start, frame end and FPS of the video file.

## Additional review information

Fix #117 

## Testing notes:

1. Publishing with video files should work as intended.
2. Publishing with image files or others should not be affected.