### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_traypublisher/api/plugin.py
+++ b/client/ayon_traypublisher/api/plugin.py
@@ -113,6 +113,15 @@ class SettingsCreator(TrayPublishCreator):
 
     skip_discovery = True
 
+    def apply_settings(self, project_settings):
+        # Ignore apply settings, only convert product type items
+        self.product_type_items = self._convert_product_type_items(
+            self.product_type_items
+        )
+        for item in self.product_type_items:
+            if not item.label and self.label:
+                item.label = f"{self.label} ({item.product_type})"
+
     def create(self, product_name, data, pre_create_data):
         # Pass precreate data to creator attributes
         thumbnail_path = pre_create_data.pop(PRE_CREATE_THUMBNAIL_KEY, None)
@@ -131,9 +140,16 @@ class SettingsCreator(TrayPublishCreator):
         data["creator_attributes"] = pre_create_data
         data["settings_creator"] = True
 
+        product_type = data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         # Create new instance
         new_instance = CreatedInstance(
-            self.product_type, product_name, data, self
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=data,
+            creator=self,
         )
 
         self._store_new_instance(new_instance)
@@ -320,18 +336,19 @@ class SettingsCreator(TrayPublishCreator):
     @classmethod
     def from_settings(cls, item_data):
         identifier = item_data["identifier"]
-        product_type = item_data["product_type"]
+        product_base_type = item_data["product_base_type"]
         if not identifier:
-            identifier = f"settings_{product_type}"
+            identifier = f"settings_{product_base_type}"
         return type(
             f"{cls.__name__}{identifier}",
             (cls, ),
             {
-                "product_base_type": product_type,
-                "product_type": product_type,
+                "product_base_type": product_base_type,
+                "product_type": product_base_type,
                 "identifier": identifier,
                 "label": item_data["label"].strip(),
                 "icon": item_data["icon"],
+                "product_type_items": item_data["product_type_items"],
                 "description": item_data["description"],
                 "detailed_description": item_data["detailed_description"],
                 "extensions": item_data["extensions"],

--- a/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
+++ b/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
@@ -30,8 +30,8 @@ class CreateColorspaceLook(TrayPublishCreator):
 
     identifier = "io.ayon.creators.traypublisher.colorspace_look"
     label = "Colorspace Look"
-    product_type = "ociolook"
     product_base_type = "ociolook"
+    product_type = product_base_type
     description = "Publishes color space look file."
     extensions = [
         ".cc", ".cube", ".3dl", ".spi1d", ".spi3d", ".csp", ".lut",

--- a/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
+++ b/client/ayon_traypublisher/plugins/create/create_colorspace_look.py
@@ -71,11 +71,16 @@ This creator publishes color space look file (LUT).
                 self.project_name, folder_entity["id"], task_name
             )
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
+
         product_name = self.get_product_name(
             project_name=self.project_name,
             folder_entity=folder_entity,
             task_entity=task_entity,
             variant=instance_data["variant"],
+            product_type=product_type,
         )
 
         instance_data["creator_attributes"] = {}
@@ -90,8 +95,13 @@ This creator publishes color space look file (LUT).
             )
 
         # Create new instance
-        new_instance = CreatedInstance(self.product_type, product_name,
-                                       instance_data, self)
+        new_instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+        )
         new_instance.transient_data["config_items"] = self.config_items
         new_instance.transient_data["config_data"] = self.config_data
 

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -198,12 +198,13 @@ class ProductItem:
     @property
     def unique_name(self) -> str:
         if self._unique_name is None:
+            product_part = (
+                f"{self.variant}{self.product_base_type}{self.version}"
+            )
             self._unique_name = "/".join([
                 self.folder_path,
                 self.task_name,
-                f"{self.variant}{self.product_type}{self.version}".replace(
-                    " ", ""
-                ).lower()
+                product_part.replace(" ", "").lower()
             ])
         return self._unique_name
 
@@ -212,7 +213,7 @@ class ProductItem:
         if self._pre_product_name is None:
             self._pre_product_name = (
                 f"{self.task_name}{self.variant}"
-                f"{self.product_type}{self.version}"
+                f"{self.product_base_type}{self.version}"
             ).replace(" ", "").lower()
         return self._pre_product_name
 
@@ -261,8 +262,8 @@ class IngestCSV(TrayPublishCreator):
     icon = "fa.file"
 
     label = "CSV Ingest"
-    product_type = "csv_ingest_file"
     product_base_type = "csv_ingest_file"
+    product_type = product_base_type
     identifier = "io.ayon.creators.traypublisher.csv_ingest"
 
     default_variants = ["Main"]
@@ -409,7 +410,7 @@ configuration in project settings.
 
         csv_instance = CreatedInstance(
             product_base_type=self.product_base_type,
-            product_type=self.product_type,
+            product_type=self.product_base_type,
             product_name=product_name,
             data=instance_data,
             creator=self

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -118,10 +118,17 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
     def create(self, instance_data, source_data=None):
         product_name = instance_data["productName"]
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
 
         # Create new instance
         new_instance = CreatedInstance(
-            self.product_type, product_name, instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
 
         self._store_new_instance(new_instance)
@@ -149,8 +156,8 @@ class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
     The shot metadata instance carrier.
     """
     identifier = "editorial_shot_advanced"
-    product_type = "shot"
     product_base_type = "shot"
+    product_type = product_base_type
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -172,8 +179,8 @@ class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
     Plate representation instance.
     """
     identifier = "editorial_plate_advanced"
-    product_type = "plate"
     product_base_type = "plate"
+    product_type = product_base_type
     label = "Plate product"
 
 
@@ -183,8 +190,8 @@ class EditorialImageInstanceCreator(EditorialClipInstanceCreatorBase):
     Plate representation instance.
     """
     identifier = "editorial_image_advanced"
-    product_type = "image"
     product_base_type = "image"
+    product_type = product_base_type
     label = "Image product"
 
 
@@ -193,8 +200,8 @@ class EditorialRenderInstanceCreator(EditorialClipInstanceCreatorBase):
     Render representation instance.
     """
     identifier = "editorial_render_advanced"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     label = "Render product"
 
 
@@ -204,8 +211,8 @@ class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
     Audio representation instance.
     """
     identifier = "editorial_audio_advanced"
-    product_type = "audio"
     product_base_type = "audio"
+    product_type = product_base_type
     label = "Audio product"
 
 
@@ -215,8 +222,8 @@ class EditorialModelInstanceCreator(EditorialClipInstanceCreatorBase):
     Model representation instance.
     """
     identifier = "editorial_model_advanced"
-    product_type = "model"
     product_base_type = "model"
+    product_type = product_base_type
     label = "Model product"
 
     def get_instance_attr_defs(self):
@@ -234,8 +241,8 @@ class EditorialCameraInstanceCreator(EditorialClipInstanceCreatorBase):
     Camera representation instance.
     """
     identifier = "editorial_camera_advanced"
-    product_type = "camera"
     product_base_type = "camera"
+    product_type = product_base_type
     label = "Camera product"
 
     def get_instance_attr_defs(self):
@@ -253,8 +260,8 @@ class EditorialWorkfileInstanceCreator(EditorialClipInstanceCreatorBase):
     Workfile representation instance.
     """
     identifier = "editorial_workfile_advanced"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     label = "Workfile product"
 
     def get_instance_attr_defs(self):
@@ -277,8 +284,8 @@ class EditorialAdvancedCreator(TrayPublishCreator):
     """
     enabled = True
     label = "Editorial Advanced"
-    product_type = "editorial"
     product_base_type = "editorial"
+    product_type = product_base_type
     identifier = "editorial_advanced"
     default_variants = [
         "main"
@@ -289,7 +296,7 @@ Supporting publishing new shots to project
 or updating already created. Publishing will create OTIO file.
 """
     icon = "fa.file"
-    product_type_presets = []
+    product_base_type_presets = []
 
     def __init__(self, *args, **kwargs):
         self._shot_metadata_solver = ShotMetadataSolver(self.log)
@@ -309,13 +316,14 @@ or updating already created. Publishing will create OTIO file.
             creator_settings["shot_hierarchy"],
             creator_settings["shot_add_tasks"]
         )
-        self.product_type_presets = creator_settings[
-            "product_type_advanced_presets"]
+        self.product_base_type_presets = creator_settings[
+            "product_base_type_advanced_presets"]
         self.default_variants = creator_settings["default_variants"]
 
     def create(self, product_name, instance_data, pre_create_data):
-        allowed_product_type_presets = self._get_allowed_product_type_presets(
-            pre_create_data)
+        allowed_product_base_type_presets = (
+            self._get_allowed_product_base_type_presets(pre_create_data)
+        )
 
         ignored_keys = set(self.get_product_presets_with_names())
         ignored_keys |= {"sequence_filepath_data", "folder_path_data"}
@@ -372,7 +380,7 @@ or updating already created. Publishing will create OTIO file.
                     otio_timeline,
                     media_folder_path,
                     clip_instance_properties,
-                    allowed_product_type_presets,
+                    allowed_product_base_type_presets,
                     sequence_name,
                     ignore_clip_no_content,
                 )
@@ -401,7 +409,11 @@ or updating already created. Publishing will create OTIO file.
             }
         )
         new_instance = CreatedInstance(
-            self.product_type, product_name, instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
         self._store_new_instance(new_instance)
 
@@ -460,7 +472,7 @@ or updating already created. Publishing will create OTIO file.
         otio_timeline,
         media_folder_path,
         instance_data,
-        product_type_presets,
+        product_base_type_presets,
         sequence_file_name,
         ignore_clip_no_content,
     ):
@@ -471,7 +483,7 @@ or updating already created. Publishing will create OTIO file.
             otio_timeline (otio.Timeline): otio timeline object
             media_folder_path (str): Folder with media files
             instance_data (dict): clip instance data
-            product_type_presets (list[dict]): list of dict settings
+            product_base_type_presets (list[dict]): list of dict settings
                 product presets
             sequence_file_name (str): sequence file name
             ignore_clip_no_content (bool): ignore clips with no content
@@ -508,7 +520,7 @@ or updating already created. Publishing will create OTIO file.
             matched_product_items = []
             for root, foldernames, filenames in os.walk(abs_clip_folder):
                 # iterate all product names in enabled presets
-                for pres_product_data in product_type_presets:
+                for pres_product_data in product_base_type_presets:
                     product_name = pres_product_data["product_name"]
 
                     product_data_base = {
@@ -595,7 +607,7 @@ or updating already created. Publishing will create OTIO file.
 
                     if not any(
                         item
-                        for preset in product_type_presets
+                        for preset in product_base_type_presets
                         for item in clip_related_content
                         if preset["product_name"] in item["product_name"]
                     ):
@@ -629,7 +641,7 @@ or updating already created. Publishing will create OTIO file.
                 abs_clip_folder = os.path.join(
                     media_folder_path, otio_clip.name).replace("\\", "/")
 
-                for pres_product_data in product_type_presets:
+                for pres_product_data in product_base_type_presets:
                     self._make_product_instance(
                         pres_product_data,
                         deepcopy(base_instance_data),
@@ -777,7 +789,7 @@ or updating already created. Publishing will create OTIO file.
             clip_content_items (list[dict]): list of clip content items
             media_folder_path (str): media folder path
         """
-        pres_product_type = product_preset["product_type"]
+        pres_product_base_type = product_preset["product_base_type"]
         pres_product_name = product_preset["product_name"]
         pres_versioning = product_preset["versioning_type"]
         pres_representations = product_preset["representations"]
@@ -909,7 +921,7 @@ or updating already created. Publishing will create OTIO file.
             instance_data = deepcopy(base_instance_data)
             self._set_product_data_to_instance(
                 instance_data,
-                pres_product_type,
+                pres_product_base_type,
                 product_name=product_name,
             )
 
@@ -923,12 +935,14 @@ or updating already created. Publishing will create OTIO file.
                 "prep_representations": representations,
             })
 
-            if pres_product_type not in ["model", "workfile", "camera"]:
+            if pres_product_base_type not in ["model", "workfile", "camera"]:
                 instance_data["creator_attributes"]["add_review_family"] = (
                     reviewable
                 )
 
-            creator_identifier = f"editorial_{pres_product_type}_advanced"
+            creator_identifier = (
+                f"editorial_{pres_product_base_type}_advanced"
+            )
             editorial_clip_creator = self.create_context.creators[
                 creator_identifier]
 
@@ -996,7 +1010,7 @@ or updating already created. Publishing will create OTIO file.
     def _set_product_data_to_instance(
         self,
         instance_data,
-        product_type,
+        product_base_type,
         variant=None,
         product_name=None,
     ):
@@ -1004,7 +1018,7 @@ or updating already created. Publishing will create OTIO file.
 
         Args:
             instance_data (dict): instance data
-            product_type (str): product type
+            product_base_type (str): product base type
             variant (Optional[str]): product variant
                 default is "main"
             product_name (Optional[str]): product name
@@ -1013,22 +1027,23 @@ or updating already created. Publishing will create OTIO file.
             str: label string
         """
         if not variant:
+            variant = "main"
             if product_name:
-                variant = product_name.split(product_type)[-1].lower()
-            else:
-                variant = "main"
+                variant = product_name.split(product_base_type)[-1].lower()
 
         folder_path = instance_data["creator_attributes"]["folderPath"]
 
         # product name
-        product_name = product_name or f"{product_type}{variant.capitalize()}"
+        if not product_name:
+            product_name = f"{product_base_type}{variant.capitalize()}"
         label = f"{folder_path} {product_name}"
 
         instance_data.update(
             {
                 "label": label,
                 "variant": variant,
-                "productType": product_type,
+                "productBaseType": product_base_type,
+                "productType": product_base_type,
                 "productName": product_name,
             }
         )
@@ -1175,8 +1190,8 @@ or updating already created. Publishing will create OTIO file.
             "sourceOut": int(source_out)
         }
 
-    def _get_allowed_product_type_presets(self, pre_create_data):
-        """Filter out allowed product type presets.
+    def _get_allowed_product_base_type_presets(self, pre_create_data):
+        """Filter out allowed product base type presets.
 
         Args:
             pre_create_data (dict): precreate attributes inputs
@@ -1184,10 +1199,11 @@ or updating already created. Publishing will create OTIO file.
         Returns:
             list: Filtered list of extended preset items.
         """
+        presets_by_name = self.get_product_presets_with_names()
         return [
             # return dict with name of preset and add preset dict
             {"product_name": product_name, **preset}
-            for product_name, preset in self.get_product_presets_with_names().items()  # noqa
+            for product_name, preset in presets_by_name.items()
             if pre_create_data[product_name]
         ]
 
@@ -1280,9 +1296,9 @@ or updating already created. Publishing will create OTIO file.
             dict: dict with product names and preset items
         """
         output = {}
-        for item in self.product_type_presets:
+        for item in self.product_base_type_presets:
             product_name = (
-                f"{item['product_type']}"
+                f"{item['product_base_type']}"
                 f"{(item['variant']).capitalize()}"
             )
             output[product_name] = item

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -113,7 +113,7 @@ VERSION_IN_FILE_PATTERN = r".*v(\d{2,4}).*"
 
 
 class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
-    """Wrapper class for clip product type creators."""
+    """Wrapper class for clip product base type creators."""
     host_name = "traypublisher"
 
     def create(self, instance_data, source_data=None):
@@ -151,7 +151,7 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
 
 class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Shot product type class
+    """Shot product base type class
 
     The shot metadata instance carrier.
     """
@@ -174,7 +174,7 @@ class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Plate product type class
+    """Plate product base type class
 
     Plate representation instance.
     """
@@ -185,7 +185,7 @@ class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialImageInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Image product type class
+    """Image product base type class
 
     Plate representation instance.
     """
@@ -196,7 +196,7 @@ class EditorialImageInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialRenderInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Render product type class
+    """Render product base type class
     Render representation instance.
     """
     identifier = "editorial_render_advanced"
@@ -206,7 +206,7 @@ class EditorialRenderInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Audio product type class
+    """Audio product base type class
 
     Audio representation instance.
     """
@@ -217,7 +217,7 @@ class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialModelInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Model product type class
+    """Model product base type class
 
     Model representation instance.
     """
@@ -237,7 +237,7 @@ class EditorialModelInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialCameraInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Camera product type class
+    """Camera product base type class
     Camera representation instance.
     """
     identifier = "editorial_camera_advanced"
@@ -255,7 +255,7 @@ class EditorialCameraInstanceCreator(EditorialClipInstanceCreatorBase):
         ]
 
 class EditorialWorkfileInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Workfile product type class
+    """Workfile product base type class
 
     Workfile representation instance.
     """
@@ -1272,8 +1272,8 @@ or updating already created. Publishing will create OTIO file.
             UISeparatorDef("two"),
         ]
 
-        # transform all items in product type presets to join product
-        # type and product variant together as single camel case string
+        # transform all items in product base type presets to join product
+        # base type and product variant together as single camel case string
         product_names = self.get_product_presets_with_names()
 
         # add variants swithers
@@ -1291,9 +1291,11 @@ or updating already created. Publishing will create OTIO file.
         return attr_defs
 
     def get_product_presets_with_names(self):
-        """Get product type presets names.
+        """Get product base type presets names.
+
         Returns:
             dict: dict with product names and preset items
+
         """
         output = {}
         for item in self.product_base_type_presets:

--- a/client/ayon_traypublisher/plugins/create/create_editorial_package.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_package.py
@@ -16,14 +16,14 @@ class EditorialPackageCreator(TrayPublishCreator):
     """Creates instance for OTIO file from published folder.
 
     Folder contains OTIO file and exported .mov files. Process should publish
-    whole folder as single `editorial_pkg` product type and (possibly) convert
-    .mov files into different format and copy them into `publish` `resources`
-    subfolder.
+    whole folder as single `editorial_pkg` product base type and (possibly)
+    convert     .mov files into different format and copy them into `publish`
+    `resources` subfolder.
     """
     identifier = "editorial_pkg"
     label = "Editorial package"
-    product_type = "editorial_pkg"
     product_base_type = "editorial_pkg"
+    product_type = product_base_type
     description = "Publish folder with OTIO file and resources"
 
     # Position batch creator after simple creators
@@ -53,9 +53,17 @@ class EditorialPackageCreator(TrayPublishCreator):
             "conversion_enabled": pre_create_data["conversion_enabled"]
         }
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         # Create new instance
-        new_instance = CreatedInstance(self.product_type, product_name,
-                                       instance_data, self)
+        new_instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+        )
         self._store_new_instance(new_instance)
 
     def get_pre_create_attr_defs(self):
@@ -91,7 +99,7 @@ class EditorialPackageCreator(TrayPublishCreator):
         return """# Publish folder with OTIO file and video clips
 
         Folder contains OTIO file and exported .mov files. Process should
-        publish whole folder as single `editorial_pkg` product type and
+        publish whole folder as single `editorial_pkg` product base type and
         (possibly) convert .mov files into different format and copy them into
         `publish` `resources` subfolder.
         """

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -93,7 +93,7 @@ CLIP_ATTR_DEFS = [
 
 
 class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
-    """Wrapper class for clip product type creators."""
+    """Wrapper class for clip product base type creators."""
     host_name = "traypublisher"
     skip_discovery = True
 
@@ -142,7 +142,7 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
 
 class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Shot product type class
+    """Shot product base type class
 
     The shot metadata instance carrier.
     """
@@ -164,7 +164,7 @@ class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Plate product type class
+    """Plate product base type class
 
     Plate representation instance.
     """
@@ -175,7 +175,7 @@ class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Audio product type class
+    """Audio product base type class
 
     Audio representation instance.
     """
@@ -186,7 +186,7 @@ class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
 
 
 class EditorialReviewInstanceCreator(EditorialClipInstanceCreatorBase):
-    """Review product type class
+    """Review product base type class
 
     Review representation instance.
     """
@@ -464,7 +464,7 @@ or updating already created. Publishing will create OTIO file.
                     product_base_type = (
                         product_base_type_preset["product_base_type"]
                     )
-                    # exclude audio product type if no audio stream
+                    # exclude audio product base type if no audio stream
                     if (
                         product_base_type == "audio"
                         and not media_data.get("audio")
@@ -593,7 +593,7 @@ or updating already created. Publishing will create OTIO file.
 
         Args:
             otio_clip (otio.Clip): otio clip object
-            product_base_type_preset (dict): single product type preset
+            product_base_type_preset (dict): single product base type preset
             instance_data (dict): instance data
             parenting_data (dict): shot instance parent data
 
@@ -607,7 +607,7 @@ or updating already created. Publishing will create OTIO file.
         )
         instance_data["label"] = label
 
-        # add file extension filter only if it is not shot product type
+        # add file extension filter only if it is not shot product base type
         if product_base_type == "shot":
             instance_data["otioClip"] = (
                 otio.adapters.write_to_string(otio_clip))
@@ -817,7 +817,7 @@ or updating already created. Publishing will create OTIO file.
         }
 
     def _get_allowed_product_base_type_presets(self, pre_create_data):
-        """Filter out allowed product type presets.
+        """Filter out allowed product base type presets.
 
         Args:
             pre_create_data (dict): precreate attributes inputs

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -254,7 +254,7 @@ or updating already created. Publishing will create OTIO file.
 
         product_base_types = {
             item["product_base_type"]
-            for item in self.productbase_type_presets
+            for item in self.product_base_type_presets
         }
         clip_instance_properties = {
             k: v

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -113,7 +113,11 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
         # Create new instance
         new_instance = CreatedInstance(
-            self.product_type, product_name, instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
 
         self._store_new_instance(new_instance)
@@ -143,8 +147,8 @@ class EditorialShotInstanceCreator(EditorialClipInstanceCreatorBase):
     The shot metadata instance carrier.
     """
     identifier = "editorial_shot"
-    product_type = "shot"
     product_base_type = "shot"
+    product_type = product_base_type
     label = "Editorial Shot"
 
     def get_instance_attr_defs(self):
@@ -165,8 +169,8 @@ class EditorialPlateInstanceCreator(EditorialClipInstanceCreatorBase):
     Plate representation instance.
     """
     identifier = "editorial_plate"
-    product_type = "plate"
     product_base_type = "plate"
+    product_type = product_base_type
     label = "Editorial Plate"
 
 
@@ -176,8 +180,8 @@ class EditorialAudioInstanceCreator(EditorialClipInstanceCreatorBase):
     Audio representation instance.
     """
     identifier = "editorial_audio"
-    product_type = "audio"
     product_base_type = "audio"
+    product_type = product_base_type
     label = "Editorial Audio"
 
 
@@ -187,8 +191,8 @@ class EditorialReviewInstanceCreator(EditorialClipInstanceCreatorBase):
     Review representation instance.
     """
     identifier = "editorial_review"
-    product_type = "review"
     product_base_type = "review"
+    product_type = product_base_type
     label = "Editorial Review"
 
 
@@ -204,8 +208,8 @@ class EditorialSimpleCreator(TrayPublishCreator):
     """
     enabled = True
     label = "Editorial Simple"
-    product_type = "editorial"
     product_base_type = "editorial"
+    product_type = product_base_type
     identifier = "editorial_simple"
     default_variants = [
         "main"
@@ -216,7 +220,7 @@ Supporting publishing new shots to project
 or updating already created. Publishing will create OTIO file.
 """
     icon = "fa.file"
-    product_type_presets = []
+    product_base_type_presets = []
 
     def __init__(self, *args, **kwargs):
         self._shot_metadata_solver = ShotMetadataSolver(self.log)
@@ -236,24 +240,27 @@ or updating already created. Publishing will create OTIO file.
             creator_settings["shot_hierarchy"],
             creator_settings["shot_add_tasks"]
         )
-        self.product_type_presets = creator_settings["product_type_presets"]
+        self.product_base_type_presets = (
+            creator_settings["product_base_type_presets"]
+        )
         default_variants = creator_settings.get("default_variants")
         if default_variants:
             self.default_variants = default_variants
 
     def create(self, product_name, instance_data, pre_create_data):
-        allowed_product_type_presets = self._get_allowed_product_type_presets(
-            pre_create_data)
+        allowed_product_base_type_presets = (
+            self._get_allowed_product_base_type_presets(pre_create_data)
+        )
 
-        product_types = {
-            item["product_type"]
-            for item in self.product_type_presets
+        product_base_types = {
+            item["product_base_type"]
+            for item in self.productbase_type_presets
         }
         clip_instance_properties = {
             k: v
             for k, v in pre_create_data.items()
             if k != "sequence_filepath_data"
-            if k not in product_types
+            if k not in product_base_types
         }
 
         folder_path = instance_data["folderPath"]
@@ -295,7 +302,7 @@ or updating already created. Publishing will create OTIO file.
                 otio_timeline,
                 media_path,
                 clip_instance_properties,
-                allowed_product_type_presets,
+                allowed_product_base_type_presets,
                 os.path.basename(seq_path),
                 first_otio_timeline,
             )
@@ -333,7 +340,11 @@ or updating already created. Publishing will create OTIO file.
             "otioTimeline": otio.adapters.write_to_string(otio_timeline)
         })
         new_instance = CreatedInstance(
-            self.product_type, product_name, data, self
+            product_base_type=self.product_base_type,
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=data,
+            creator=self,
         )
         self._store_new_instance(new_instance)
 
@@ -392,7 +403,7 @@ or updating already created. Publishing will create OTIO file.
         otio_timeline,
         media_path,
         instance_data,
-        product_type_presets,
+        product_base_type_presets,
         sequence_file_name,
         first_otio_timeline=None
     ):
@@ -403,7 +414,8 @@ or updating already created. Publishing will create OTIO file.
             otio_timeline (otio.Timeline): otio timeline object
             media_path (str): media file path string
             instance_data (dict): clip instance data
-            product_type_presets (list): list of dict settings product presets
+            product_base_type_presets (list): list of dict settings
+                product presets
         """
 
         tracks = otio_timeline.video_tracks()
@@ -448,17 +460,20 @@ or updating already created. Publishing will create OTIO file.
                     "instance_id": None
                 }
 
-                for product_type_preset in product_type_presets:
+                for product_base_type_preset in product_base_type_presets:
+                    product_base_type = (
+                        product_base_type_preset["product_base_type"]
+                    )
                     # exclude audio product type if no audio stream
                     if (
-                        product_type_preset["product_type"] == "audio"
+                        product_base_type == "audio"
                         and not media_data.get("audio")
                     ):
                         continue
 
                     self._make_product_instance(
                         otio_clip,
-                        product_type_preset,
+                        product_base_type_preset,
                         deepcopy(base_instance_data),
                         parenting_data
                     )
@@ -570,7 +585,7 @@ or updating already created. Publishing will create OTIO file.
     def _make_product_instance(
         self,
         otio_clip,
-        product_type_preset,
+        product_base_type_preset,
         instance_data,
         parenting_data
     ):
@@ -578,22 +593,22 @@ or updating already created. Publishing will create OTIO file.
 
         Args:
             otio_clip (otio.Clip): otio clip object
-            product_type_preset (dict): single product type preset
+            product_base_type_preset (dict): single product type preset
             instance_data (dict): instance data
             parenting_data (dict): shot instance parent data
 
         Returns:
             CreatedInstance: creator instance object
         """
-        product_type = product_type_preset["product_type"]
+        product_base_type = product_base_type_preset["product_base_type"]
         label = self._make_product_naming(
-            product_type_preset,
+            product_base_type_preset,
             instance_data
         )
         instance_data["label"] = label
 
         # add file extension filter only if it is not shot product type
-        if product_type == "shot":
+        if product_base_type == "shot":
             instance_data["otioClip"] = (
                 otio.adapters.write_to_string(otio_clip))
             c_instance = self.create_context.creators[
@@ -606,15 +621,17 @@ or updating already created. Publishing will create OTIO file.
         else:
             # add review family if defined
             instance_data.update({
-                "outputFileType": product_type_preset["output_file_type"],
+                "outputFileType": product_base_type_preset["output_file_type"],
                 "parent_instance_id": parenting_data["instance_id"],
                 "creator_attributes": {
                     "parent_instance": parenting_data["instance_label"],
-                    "add_review_family": product_type_preset.get("review")
+                    "add_review_family": product_base_type_preset.get(
+                        "review"
+                    )
                 }
             })
 
-            creator_identifier = f"editorial_{product_type}"
+            creator_identifier = f"editorial_{product_base_type}"
             editorial_clip_creator = self.create_context.creators[
                 creator_identifier]
             c_instance = editorial_clip_creator.create(
@@ -622,11 +639,11 @@ or updating already created. Publishing will create OTIO file.
 
         return c_instance
 
-    def _make_product_naming(self, product_type_preset, instance_data):
+    def _make_product_naming(self, product_base_type_preset, instance_data):
         """Product name maker
 
         Args:
-            product_type_preset (dict): single preset item
+            product_base_type_preset (dict): single preset item
             instance_data (dict): instance data
 
         Returns:
@@ -635,24 +652,22 @@ or updating already created. Publishing will create OTIO file.
         folder_path = instance_data["creator_attributes"]["folderPath"]
 
         variant_name = instance_data["variant"]
-        product_type = product_type_preset["product_type"]
+        product_base_type = product_base_type_preset["product_base_type"]
 
         # get variant name from preset or from inheritance
-        _variant_name = product_type_preset.get("variant") or variant_name
+        _variant_name = product_base_type_preset.get("variant") or variant_name
 
         # product name
         product_name = "{}{}".format(
-            product_type, _variant_name.capitalize()
+            product_base_type, _variant_name.capitalize()
         )
-        label = "{} {}".format(
-            folder_path,
-            product_name
-        )
+        label = f"{folder_path} {product_name}"
 
         instance_data.update({
             "label": label,
             "variant": _variant_name,
-            "productType": product_type,
+            "productBaseType": product_base_type,
+            "productType": product_base_type,
             "productName": product_name,
         })
 
@@ -801,7 +816,7 @@ or updating already created. Publishing will create OTIO file.
             "sourceOut": int(source_out)
         }
 
-    def _get_allowed_product_type_presets(self, pre_create_data):
+    def _get_allowed_product_base_type_presets(self, pre_create_data):
         """Filter out allowed product type presets.
 
         Args:
@@ -811,11 +826,11 @@ or updating already created. Publishing will create OTIO file.
             list: lit of dict with preset items
         """
         return [
-            {"product_type": "shot"},
+            {"product_base_type": "shot"},
             *[
                 preset
-                for preset in self.product_type_presets
-                if pre_create_data[preset["product_type"]]
+                for preset in self.product_base_type_presets
+                if pre_create_data[preset["product_base_type"]]
             ]
         ]
 
@@ -897,8 +912,11 @@ or updating already created. Publishing will create OTIO file.
         ]
         # add variants swithers
         attr_defs.extend(
-            BoolDef(item["product_type"], label=item["product_type"])
-            for item in self.product_type_presets
+            BoolDef(
+                item["product_base_type"],
+                label=item["product_base_type"],
+            )
+            for item in self.product_base_type_presets
         )
         attr_defs.append(UISeparatorDef())
 

--- a/client/ayon_traypublisher/plugins/create/create_movie_batch.py
+++ b/client/ayon_traypublisher/plugins/create/create_movie_batch.py
@@ -9,6 +9,7 @@ import ayon_api
 from ayon_core.lib import (
     FileDef,
     BoolDef,
+    EnumDef,
 )
 from ayon_core.pipeline import (
     CreatedInstance,
@@ -41,6 +42,7 @@ class BatchMovieCreator(TrayPublishCreator):
     version_regex = re.compile(r"^(.+)_v([0-9]+)$")
     # Position batch creator after simple creators
     order = 110
+    product_types = []
 
     def get_icon(self):
         return "fa.file"
@@ -170,6 +172,10 @@ class BatchMovieCreator(TrayPublishCreator):
         ]
 
     def get_pre_create_attr_defs(self):
+        product_types = self.product_types
+        if not product_types:
+            product_types = ["render"]
+
         # Use same attributes as for instance attributes
         return [
             FileDef(
@@ -184,7 +190,12 @@ class BatchMovieCreator(TrayPublishCreator):
                 "add_review_family",
                 default=True,
                 label="Review"
-            )
+            ),
+            EnumDef(
+                "product_type",
+                items=product_types,
+                label="Product type",
+            ),
         ]
 
     def get_detail_description(self) -> str:

--- a/client/ayon_traypublisher/plugins/create/create_movie_batch.py
+++ b/client/ayon_traypublisher/plugins/create/create_movie_batch.py
@@ -41,14 +41,6 @@ class BatchMovieCreator(TrayPublishCreator):
     # Position batch creator after simple creators
     order = 110
 
-    def apply_settings(self, project_settings):
-        creator_settings = (
-            project_settings["traypublisher"]["create"]["BatchMovieCreator"]
-        )
-        self.default_variants = creator_settings["default_variants"]
-        self.default_tasks = creator_settings["default_tasks"]
-        self.extensions = creator_settings["extensions"]
-
     def get_icon(self):
         return "fa.file"
 

--- a/client/ayon_traypublisher/plugins/create/create_movie_batch.py
+++ b/client/ayon_traypublisher/plugins/create/create_movie_batch.py
@@ -2,6 +2,7 @@ import copy
 import os
 import re
 import collections
+from typing import Any, Optional
 
 import ayon_api
 
@@ -32,8 +33,8 @@ class BatchMovieCreator(TrayPublishCreator):
     """
     identifier = "render_movie_batch"
     label = "Batch Movies"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     description = "Publish batch of video files"
 
     create_allow_context_change = False
@@ -94,7 +95,9 @@ class BatchMovieCreator(TrayPublishCreator):
                         task_entity = task_entities_by_name[_name]
                         task_name = task_entity["name"]
                         break
-
+                product_type = instance_data.get("productType")
+                if not product_type:
+                    product_type = self.product_base_type
                 product_name = self._get_product_name(
                     self.project_name,
                     project_settings,
@@ -102,6 +105,7 @@ class BatchMovieCreator(TrayPublishCreator):
                     folder_entity,
                     task_entity,
                     data["variant"],
+                    product_type,
                 )
 
                 instance_data["folderPath"] = folder_entity["path"]
@@ -109,68 +113,50 @@ class BatchMovieCreator(TrayPublishCreator):
 
                 # Create new instance
                 new_instance = CreatedInstance(
+                    product_base_type=self.product_base_type,
+                    product_type=product_type,
+                    product_name=product_name,
                     data=instance_data,
                     creator=self,
-                    product_type=self.product_base_type,
-                    product_name=product_name,
                 )
                 self._store_new_instance(new_instance)
 
     def _get_product_name(
         self,
-        project_name,
-        project_settings,
-        project_entity,
-        folder_entity,
-        task_entity,
-        variant,
-    ):
+        project_name: str,
+        project_settings: dict[str, Any],
+        project_entity: dict[str, Any],
+        folder_entity: dict[str, Any],
+        task_entity: Optional[dict[str, Any]],
+        variant: str,
+        product_type: str,
+    ) -> str:
         """Create product name according to standard template process"""
-        host_name = self.create_context.host_name
-        get_product_name_kwargs = dict(
+        kwargs = dict(
             project_name=project_name,
-            product_type=self.product_type,
+            project_entity=project_entity,
+            folder_entity=folder_entity,
+            task_entity=task_entity,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             variant=variant,
-            host_name=host_name,
+            host_name=self.create_context.host_name,
+            project_settings=project_settings,
         )
-        if getattr(get_product_name, "use_entities", False):
-            get_product_name_kwargs.update({
-                "folder_entity": folder_entity,
-                "task_entity": task_entity,
-                "project_entity": project_entity,
-                "project_settings": project_settings,
-                "product_base_type": self.product_base_type,
-            })
-        else:
-            task_name = task_type = None
-            if task_entity:
-                task_name = task_entity["name"]
-                task_type = task_entity["type"]
-            get_product_name_kwargs.update({
-                "task_name": task_name,
-                "task_type": task_type,
-            })
         try:
-            product_name = get_product_name(**get_product_name_kwargs)
+            product_name = get_product_name(**kwargs)
         except TaskNotSetError:
             # Create instance with fake task
             # - instance will be marked as invalid so it can't be published
             #   but user have ability to change it
             # NOTE: This expect that there is not task 'Undefined' on folder
+            kwargs["task_entity"] = {
+                "type": "Undefined",
+                "name": "Undefined",
+                "label": "Undefined",
+            }
 
-            if getattr(get_product_name, "use_entities", False):
-                get_product_name_kwargs["task_entity"] = {
-                    "type": "Undefined",
-                    "name": "Undefined",
-                    "label": "Undefined",
-                }
-            else:
-                get_product_name_kwargs.update({
-                    "task_name": "Undefined",
-                    "task_type": "Undefined",
-                })
-
-            product_name = get_product_name(**get_product_name_kwargs)
+            product_name = get_product_name(**kwargs)
 
         return product_name
 
@@ -201,7 +187,7 @@ class BatchMovieCreator(TrayPublishCreator):
             )
         ]
 
-    def get_detail_description(self):
+    def get_detail_description(self) -> str:
         return """# Publish batch of .mov to multiple folders.
 
         File names must then contain only folder name, or folder name + version.

--- a/client/ayon_traypublisher/plugins/create/create_online.py
+++ b/client/ayon_traypublisher/plugins/create/create_online.py
@@ -20,8 +20,8 @@ class OnlineCreator(TrayPublishCreator):
 
     identifier = "io.ayon.creators.traypublisher.online"
     label = "Online"
-    product_type = "online"
     product_base_type = "online"
+    product_type = product_base_type
     description = "Publish file retaining its original file name"
     extensions = [".mov", ".mp4", ".mxf", ".m4v", ".mpg", ".exr",
                   ".dpx", ".tif", ".png", ".jpg"]
@@ -55,9 +55,17 @@ class OnlineCreator(TrayPublishCreator):
         # Pass pre-create attributes to instance creator attributes
         instance_data["creator_attributes"] = pre_create_data
 
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         # Create new instance
-        new_instance = CreatedInstance(self.product_type, product_name,
-                                       instance_data, self)
+        new_instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+        )
         self._store_new_instance(new_instance)
 
     def get_instance_attr_defs(self):

--- a/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
+++ b/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+import copy
 import inspect
 from typing import Optional
 
-from ayon_core.lib import FileDef, BoolDef
+from ayon_core.lib import FileDef, BoolDef, EnumDef
 from ayon_core.pipeline import (
     CreatedInstance,
     CreatorError,
@@ -28,6 +29,8 @@ class PSDWorkfileCreator(TrayPublishCreator):
     settings_category = "traypublisher"
 
     default_variants = ["Main"]
+    workfile_product_types = []
+    image_product_types = []
 
     def get_detail_description(self):
         return inspect.cleandoc("""# Workfile + Image
@@ -51,11 +54,18 @@ class PSDWorkfileCreator(TrayPublishCreator):
             "filepath": repr_file,
         }
 
+        workfile_product_type = pre_create_data.get("workfile_product_type")
+        if not workfile_product_type:
+            workfile_product_type = "workfile"
+        image_product_type = pre_create_data.get("image_product_type")
+        if not image_product_type:
+            image_product_type = "image"
+
         instance_data["default_variants"] = self.default_variants
 
         workfile_instance = CreatedInstance(
             product_base_type=self.product_base_type,
-            product_type=self.product_base_type,
+            product_type=workfile_product_type,
             product_name=product_name,
             data=instance_data,
             creator=self,
@@ -63,17 +73,20 @@ class PSDWorkfileCreator(TrayPublishCreator):
 
         self._store_new_instance(workfile_instance)
 
-        add_review_family = pre_create_data.get("add_review_family", False)
-        instance_data["creator_attributes"]["add_review_family"] = (
-            add_review_family
-        )
         image_creator = self._get_hidden_creator(
             "io.ayon.creators.traypublisher.psd_workfile_image.image"
         )
         if not image_creator:
             raise CreatorError("Image creator not found")
 
-        image_creator.create(instance_data)
+        add_review_family = pre_create_data.get("add_review_family", False)
+        image_instance_data = copy.deepcopy(instance_data)
+        image_instance_data["creator_attributes"]["add_review_family"] = (
+            add_review_family
+        )
+        image_instance_data["productType"] = image_product_type
+
+        image_creator.create(image_instance_data)
 
     def _get_hidden_creator(self, identifier):
         creator = self.create_context.creators.get(identifier)
@@ -84,6 +97,13 @@ class PSDWorkfileCreator(TrayPublishCreator):
         return creator
 
     def get_pre_create_attr_defs(self):
+        workfile_product_types = self.workfile_product_types
+        image_product_types = self.image_product_types
+        if not workfile_product_types:
+            workfile_product_types = ["workfile"]
+        if not image_product_types:
+            image_product_types = ["image"]
+
         return [
             FileDef(
                 "filepath",
@@ -97,6 +117,16 @@ class PSDWorkfileCreator(TrayPublishCreator):
                 "add_review_family",
                 default=True,
                 label="Review"
+            ),
+            EnumDef(
+                "workfile_product_type",
+                label="Workfile product type",
+                items=workfile_product_types,
+            ),
+            EnumDef(
+                "image_product_type",
+                label="Image product type",
+                items=image_product_types,
             ),
         ]
 

--- a/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
+++ b/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
@@ -23,8 +23,8 @@ class PSDWorkfileCreator(TrayPublishCreator):
     description = (
         "Creates additional image publish instances for provided workfile."
     )
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     settings_category = "traypublisher"
 
     default_variants = ["Main"]
@@ -54,7 +54,11 @@ class PSDWorkfileCreator(TrayPublishCreator):
         instance_data["default_variants"] = self.default_variants
 
         workfile_instance = CreatedInstance(
-            self.product_type, product_name, instance_data, self
+            product_base_type=self.product_base_type,
+            product_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
 
         self._store_new_instance(workfile_instance)
@@ -115,8 +119,8 @@ class ImageComboCreator(HiddenTrayPublishCreator):
     identifier = "io.ayon.creators.traypublisher.psd_workfile_image.image"
     label = "Image"
     host_name = "traypublisher"
-    product_type = "image"
     product_base_type = "image"
+    product_type = product_base_type
 
     def create(self, _product_name, instance_data):
         project_entity = self.create_context.get_current_project_entity()
@@ -135,17 +139,23 @@ class ImageComboCreator(HiddenTrayPublishCreator):
             instance_data.get("variant") or
             next(iter(instance_data["default_variants"]), None)
         )
-
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         product_name = self.get_product_name(
             project_name=project_name,
             project_entity=project_entity,
             folder_entity=folder_entity,
             task_entity=task_entity,
+            variant=variant,
             host_name=host_name,
-            variant=variant
         )
         new_instance = CreatedInstance(
-            self.product_type, product_name, instance_data, self
+            product_type=product_type,
+            product_base_type=self.product_base_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
         )
 
         self._store_new_instance(new_instance)

--- a/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
+++ b/client/ayon_traypublisher/plugins/create/create_psd_workfile.py
@@ -73,7 +73,7 @@ class PSDWorkfileCreator(TrayPublishCreator):
         if not image_creator:
             raise CreatorError("Image creator not found")
 
-        image_creator.create(None, instance_data)
+        image_creator.create(instance_data)
 
     def _get_hidden_creator(self, identifier):
         creator = self.create_context.creators.get(identifier)
@@ -122,7 +122,7 @@ class ImageComboCreator(HiddenTrayPublishCreator):
     product_base_type = "image"
     product_type = product_base_type
 
-    def create(self, _product_name, instance_data):
+    def create(self, instance_data):
         project_entity = self.create_context.get_current_project_entity()
         folder_path: str = instance_data["folderPath"]
         task_name: Optional[str] = instance_data.get("task")

--- a/client/ayon_traypublisher/plugins/create/create_texture.py
+++ b/client/ayon_traypublisher/plugins/create/create_texture.py
@@ -26,8 +26,8 @@ class TextureCreator(TrayPublishCreator):
 
     identifier = "io.ayon.creators.traypublisher.texture"
     label = "Texture"
-    product_type = "texture"
     product_base_type = "texture"
+    product_type = product_base_type
     icon = "fa.file"
     description = "Texture files or UDIM sequences"
 
@@ -174,8 +174,16 @@ class TextureCreator(TrayPublishCreator):
         instance_data.setdefault("families", []).append("texture_creator")
 
         # Create new instance
-        new_instance = CreatedInstance(self.product_type, product_name,
-                                       instance_data, self)
+        product_type = instance_data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
+        new_instance = CreatedInstance(
+            product_base_type=self.product_base_type,
+            product_type=product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+        )
         self._store_new_instance(new_instance)
 
     def _get_udim_attr_def(self) -> BoolDef:

--- a/client/ayon_traypublisher/plugins/publish/collect_psd_workfile.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_psd_workfile.py
@@ -41,7 +41,7 @@ class CollectPSDWorkfile(
 
         file_url = os.path.join(filepath_def["directory"], file_name)
         add_review_family = creator_attributes.get("add_review_family", False)
-        if instance.data["productType"] == "image" and add_review_family:
+        if instance.data["productBaseType"] == "image" and add_review_family:
             repre["tags"].append("review")
             instance.data["families"].append("review")
             if not instance.data.get("thumbnailSource"):

--- a/client/ayon_traypublisher/plugins/publish/validate_filepaths.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_filepaths.py
@@ -28,22 +28,23 @@ class ValidateFilePath(pyblish.api.InstancePlugin):
             ))
             return
 
-        product_type = instance.data["productType"]
+        product_base_type = instance.data["productBaseType"]
         label = instance.data["name"]
         filepaths = instance.data["sourceFilepaths"]
         if not filepaths:
             raise PublishValidationError(
                 (
-                    "Source filepaths of '{}' instance \"{}\" are not filled"
-                ).format(product_type, label),
+                    f"Source filepaths of '{product_base_type}'"
+                    f" instance \"{label}\" are not filled"
+                ),
                 "File not filled",
                 (
                     "## Files were not filled"
                     "\nThis mean that you didn't enter any files into required"
                     " file input."
                     "\n- Please refresh publishing and check instance"
-                    " <b>{}</b>"
-                ).format(label)
+                    f" <b>{label}</b>"
+                )
             )
 
         not_found_files = [

--- a/client/ayon_traypublisher/plugins/publish/validate_filepaths.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_filepaths.py
@@ -31,21 +31,20 @@ class ValidateFilePath(pyblish.api.InstancePlugin):
         product_base_type = instance.data["productBaseType"]
         label = instance.data["name"]
         filepaths = instance.data["sourceFilepaths"]
+        error_title = "File not filled"
         if not filepaths:
-            raise PublishValidationError(
-                (
-                    f"Source filepaths of '{product_base_type}'"
-                    f" instance \"{label}\" are not filled"
-                ),
-                "File not filled",
-                (
-                    "## Files were not filled"
-                    "\nThis mean that you didn't enter any files into required"
-                    " file input."
-                    "\n- Please refresh publishing and check instance"
-                    f" <b>{label}</b>"
-                )
+            message = (
+                f"Source filepaths of '{product_base_type}'"
+                f" instance \"{label}\" are not filled"
             )
+            description = (
+                "## Files were not filled"
+                "\nThis mean that you didn't enter any files into required"
+                " file input."
+                "\n- Please refresh publishing and check instance"
+                f" <b>{label}</b>"
+            )
+            raise PublishValidationError(message, error_title, description)
 
         not_found_files = [
             filepath
@@ -53,17 +52,16 @@ class ValidateFilePath(pyblish.api.InstancePlugin):
             if not os.path.exists(filepath)
         ]
         if not_found_files:
-            joined_paths = "\n".join([
-                "- {}".format(filepath)
+            joined_paths = "\n".join(
+                f"- {filepath}"
                 for filepath in not_found_files
-            ])
-            raise PublishValidationError(
-                (
-                    "Filepath of '{}' instance \"{}\" does not exist:\n{}"
-                ).format(product_type, label, joined_paths),
-                "File not found",
-                (
-                    "## Files were not found\nFiles\n{}"
-                    "\n\nCheck if the path is still available."
-                ).format(joined_paths)
             )
+            message = (
+                f"Filepath of '{product_base_type}' instance \"{label}\""
+                f" does not exist:\n{joined_paths}"
+            )
+            description = (
+                f"## Files were not found\nFiles\n{joined_paths}"
+                "\n\nCheck if the path is still available."
+            )
+            raise PublishValidationError(message, error_title, description)

--- a/package.py
+++ b/package.py
@@ -8,6 +8,6 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">1.1.2",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {}

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -29,9 +29,27 @@ def _convert_csv_ingest_0_3_9(overrides):
         overrides["create"]["IngestCSV"]["presets"] = [default_preset]
 
 
+def _convert_editorial_0_4_0(overrides):
+    editorial_creators = overrides.get("editorial_creators", {})
+    editorial_advanced = editorial_creators.get("editorial_advanced", {})
+    if "product_type_advanced_presets" in editorial_advanced:
+        presets = editorial_advanced.pop("product_type_advanced_presets")
+        for preset in presets:
+            preset["product_base_type"] = preset.pop("product_type")
+        editorial_advanced["product_base_type_advanced_presets"] = presets
+
+    editorial_simple = editorial_creators.get("editorial_simple", {})
+    if "product_base_type_presets" in editorial_advanced:
+        presets = editorial_advanced.pop("product_base_type_presets")
+        for preset in presets:
+            preset["product_base_type"] = preset.pop("product_type")
+        editorial_advanced["product_base_type_presets"] = presets
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
     _convert_csv_ingest_0_3_9(overrides)
+    _convert_editorial_0_4_0(overrides)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -29,6 +29,17 @@ def _convert_csv_ingest_0_3_9(overrides):
         overrides["create"]["IngestCSV"]["presets"] = [default_preset]
 
 
+def _convert_simple_creators_0_4_0(overrides):
+    simple_creators = overrides.get("simple_creators")
+    if not simple_creators:
+        return
+
+    for plugin in simple_creators:
+        if "product_base_type" in plugin or "product_type" not in plugin:
+            return
+        plugin["product_base_type"] = plugin.pop("product_type")
+
+
 def _convert_editorial_0_4_0(overrides):
     editorial_creators = overrides.get("editorial_creators", {})
     editorial_advanced = editorial_creators.get("editorial_advanced", {})
@@ -51,5 +62,6 @@ def convert_settings_overrides(
     overrides: dict[str, Any],
 ) -> dict[str, Any]:
     _convert_csv_ingest_0_3_9(overrides)
+    _convert_simple_creators_0_4_0(overrides)
     _convert_editorial_0_4_0(overrides)
     return overrides

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -50,11 +50,11 @@ def _convert_editorial_0_4_0(overrides):
         editorial_advanced["product_base_type_advanced_presets"] = presets
 
     editorial_simple = editorial_creators.get("editorial_simple", {})
-    if "product_base_type_presets" in editorial_advanced:
-        presets = editorial_advanced.pop("product_base_type_presets")
+    if "product_base_type_presets" in editorial_simple:
+        presets = editorial_simple.pop("product_base_type_presets")
         for preset in presets:
             preset["product_base_type"] = preset.pop("product_type")
-        editorial_advanced["product_base_type_presets"] = presets
+        editorial_simple["product_base_type_presets"] = presets
 
 
 def convert_settings_overrides(

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,4 +1,5 @@
 from pydantic import validator
+
 from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
@@ -7,6 +8,19 @@ from ayon_server.settings import (
 )
 from ayon_server.settings.validators import ensure_unique_names
 from ayon_server.exceptions import BadRequestException
+
+
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
 
 
 class BatchMovieCreatorPlugin(BaseSettingsModel):
@@ -199,7 +213,7 @@ class FolderCreationConfigModel(BaseSettingsModel):
 class PSDWorkfileCreatorPluginModel(BaseSettingsModel):
     """Creates the workfile and image publish instances together.
 
-    For .psd which could be both workfile and image product type.
+    For .psd which could be both workfile and image product base type.
     """
     enabled: bool = SettingsField(
         title="Enabled",
@@ -262,6 +276,13 @@ class TextureCreatorPluginModel(BaseSettingsModel):
         default_factory=list,
         description=(
             "List of file extensions that are allowed as textures."
+        )
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
         )
     )
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -32,14 +32,16 @@ class BatchMovieCreatorPlugin(BaseSettingsModel):
         title="Default variants",
         default_factory=list
     )
-
     default_tasks: list[str] = SettingsField(
         title="Default tasks",
         default_factory=list
     )
-
     extensions: list[str] = SettingsField(
         title="Extensions",
+        default_factory=list
+    )
+    product_types: list[str] = SettingsField(
+        title="Product types",
         default_factory=list
     )
 
@@ -311,10 +313,11 @@ DEFAULT_CREATORS = {
         "default_variants": ["Main"],
         "default_tasks": ["Compositing"],
         "extensions": [".mov"],
+        "product_types": [],
     },
     "PSDWorkfileCreator": {
         "enabled": False,
-        "default_variants": ["Main"]
+        "default_variants": ["Main"],
     },
     "IngestCSV": {
         "enabled": True,

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -223,7 +223,15 @@ class PSDWorkfileCreatorPluginModel(BaseSettingsModel):
     )
     default_variants: list[str] = SettingsField(
         title="Default variants",
-        default_factory=list
+        default_factory=list,
+    )
+    workfile_product_types: list[str] = SettingsField(
+        title="Workfile product types",
+        default_factory=list,
+    )
+    image_product_types: list[str] = SettingsField(
+        title="Image  product types",
+        default_factory=list,
     )
 
 
@@ -318,6 +326,8 @@ DEFAULT_CREATORS = {
     "PSDWorkfileCreator": {
         "enabled": False,
         "default_variants": ["Main"],
+        "workfile_product_types": [],
+        "image_product_types": [],
     },
     "IngestCSV": {
         "enabled": True,

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -8,7 +8,7 @@ from ayon_server.settings import (
 from ayon_server.exceptions import BadRequestException
 
 
-def get_product_type_enum():
+def get_product_base_type_enum():
     return [
         {"label": "Image", "value": "image"},
         {"label": "Plate", "value": "plate"},
@@ -171,10 +171,10 @@ class ShotHierarchySubmodel(BaseSettingsModel):
     )
 
 
-class ProductTypePresetItem(BaseSettingsModel):
+class ProductBaseTypePresetItem(BaseSettingsModel):
     _layout = "compact"
 
-    product_type: str = SettingsField("", title="Product type")
+    product_base_type: str = SettingsField("", title="Product base type")
     # TODO add placeholder '< Inherited >'
     variant: str = SettingsField("", title="Variant")
     review: bool = SettingsField(True, title="Review")
@@ -184,12 +184,12 @@ class ProductTypePresetItem(BaseSettingsModel):
     )
 
 
-class ProductTypeAdvancedPresetItem(BaseSettingsModel):
+class ProductBaseTypeAdvancedPresetItem(BaseSettingsModel):
     default_enabled: bool = True
-    product_type: str = SettingsField(
+    product_base_type: str = SettingsField(
         "plate",
-        title="Product type",
-        enum_resolver=get_product_type_enum
+        title="Product base type",
+        enum_resolver=get_product_base_type_enum
     )
     variant: str = SettingsField("", title="Variant")
     versioning_type: str = SettingsField(
@@ -245,7 +245,7 @@ class EditorialSimpleCreatorPlugin(BaseSettingsModel):
         default_factory=ShotAddTasksItem,
         description="The following list of tasks will be added to each created shot."
     )
-    product_type_presets: list[ProductTypePresetItem] = SettingsField(
+    product_base_type_presets: list[ProductBaseTypePresetItem] = SettingsField(
         default_factory=list
     )
 
@@ -272,22 +272,22 @@ class EditorialAdvancedCreatorPlugin(BaseSettingsModel):
     shot_add_tasks: list[ShotAddTasksItem] = SettingsField(
         title="Add tasks to shot", default_factory=ShotAddTasksItem
     )
-    product_type_advanced_presets: list[ProductTypeAdvancedPresetItem] = (
+    product_base_type_advanced_presets: list[ProductBaseTypeAdvancedPresetItem] = (
         SettingsField(
             title="Product type presets",
             default_factory=list
         )
     )
 
-    @validator("product_type_advanced_presets")
+    @validator("product_base_type_advanced_presets")
     def validate_unique_product_names(cls, value):
         product_names = []
         for item in value:
-            product_name = item.product_type + item.variant
+            product_name = item.product_base_type + item.variant
             if product_name in product_names:
                 raise BadRequestException(
                     "Duplicate product preset: \n"
-                    f" > Product type: {item.product_type} \n"
+                    f" > Product type: {item.product_base_type} \n"
                     f" > Variant: {item.variant}"
                 )
             product_names.append(product_name)
@@ -335,21 +335,21 @@ DEFAULT_EDITORIAL_CREATORS = {
             ],
         },
         "shot_add_tasks": [],
-        "product_type_presets": [
+        "product_base_type_presets": [
             {
-                "product_type": "review",
+                "product_base_type": "review",
                 "variant": "Reference",
                 "review": True,
                 "output_file_type": ".mp4",
             },
             {
-                "product_type": "plate",
+                "product_base_type": "plate",
                 "variant": "",
                 "review": False,
                 "output_file_type": ".mov",
             },
             {
-                "product_type": "audio",
+                "product_base_type": "audio",
                 "variant": "",
                 "review": False,
                 "output_file_type": ".wav",
@@ -385,10 +385,10 @@ DEFAULT_EDITORIAL_CREATORS = {
             ],
         },
         "shot_add_tasks": [],
-        "product_type_advanced_presets": [
+        "product_base_type_advanced_presets": [
             {
                 "default_enabled": True,
-                "product_type": "plate",
+                "product_base_type": "plate",
                 "variant": "Reference",
                 "representations": [
                     {

--- a/server/settings/editorial_creators.py
+++ b/server/settings/editorial_creators.py
@@ -274,7 +274,7 @@ class EditorialAdvancedCreatorPlugin(BaseSettingsModel):
     )
     product_base_type_advanced_presets: list[ProductBaseTypeAdvancedPresetItem] = (
         SettingsField(
-            title="Product type presets",
+            title="Product base type presets",
             default_factory=list
         )
     )
@@ -287,7 +287,7 @@ class EditorialAdvancedCreatorPlugin(BaseSettingsModel):
             if product_name in product_names:
                 raise BadRequestException(
                     "Duplicate product preset: \n"
-                    f" > Product type: {item.product_base_type} \n"
+                    f" > Product base type: {item.product_base_type} \n"
                     f" > Variant: {item.variant}"
                 )
             product_names.append(product_name)

--- a/server/settings/simple_creators.py
+++ b/server/settings/simple_creators.py
@@ -8,17 +8,11 @@ class SimpleCreatorPlugin(BaseSettingsModel):
     product_base_type: str = SettingsField(
         "", title="Product base type"
     )
-    product_type_items: list[ProductTypeItemModel] = SettingsField(
-        default_factory=list,
-        title="Product type items",
-        description=(
-            "Optional list of product types that this plugin can create."
-        )
-    )
     identifier: str = SettingsField(
         "",
         title="Identifier",
         description="Product base type is used if not filled",
+        placeholder="Use product base type name (Must be unique)",
     )
     label: str = SettingsField("", title="Label")
     icon: str = SettingsField("", title="Icon")
@@ -51,6 +45,13 @@ class SimpleCreatorPlugin(BaseSettingsModel):
     extensions: list[str] = SettingsField(
         default_factory=list,
         title="Extensions"
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
     )
 
 

--- a/server/settings/simple_creators.py
+++ b/server/settings/simple_creators.py
@@ -1,11 +1,25 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
+from .creator_plugins import ProductTypeItemModel
+
 
 class SimpleCreatorPlugin(BaseSettingsModel):
     _layout = "expanded"
-    product_type: str = SettingsField("", title="Product type")
-    # TODO add placeholder
-    identifier: str = SettingsField("", title="Identifier")
+    product_base_type: str = SettingsField(
+        "", title="Product base type"
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
+    identifier: str = SettingsField(
+        "",
+        title="Identifier",
+        description="Product base type is used if not filled",
+    )
     label: str = SettingsField("", title="Label")
     icon: str = SettingsField("", title="Icon")
     default_variants: list[str] = SettingsField(
@@ -42,8 +56,9 @@ class SimpleCreatorPlugin(BaseSettingsModel):
 
 DEFAULT_SIMPLE_CREATORS = [
     {
-        "product_type": "workfile",
+        "product_base_type": "workfile",
         "identifier": "",
+        "product_type_items": [],
         "label": "Workfile",
         "icon": "fa.file",
         "default_variants": [
@@ -76,8 +91,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "model",
+        "product_base_type": "model",
         "identifier": "",
+        "product_type_items": [],
         "label": "Model",
         "icon": "fa.cubes",
         "default_variants": [
@@ -104,8 +120,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "pointcache",
+        "product_base_type": "pointcache",
         "identifier": "",
+        "product_type_items": [],
         "label": "Pointcache",
         "icon": "fa.gears",
         "default_variants": [
@@ -124,8 +141,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "plate",
+        "product_base_type": "plate",
         "identifier": "",
+        "product_type_items": [],
         "label": "Plate",
         "icon": "mdi.camera-image",
         "default_variants": [
@@ -155,8 +173,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "render",
+        "product_base_type": "render",
         "identifier": "",
+        "product_type_items": [],
         "label": "Render",
         "icon": "mdi.folder-multiple-image",
         "default_variants": [],
@@ -181,8 +200,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "camera",
+        "product_base_type": "camera",
         "identifier": "",
+        "product_type_items": [],
         "label": "Camera",
         "icon": "fa.video-camera",
         "default_variants": [],
@@ -201,8 +221,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "image",
+        "product_base_type": "image",
         "identifier": "",
+        "product_type_items": [],
         "label": "Image",
         "icon": "fa.image",
         "default_variants": [
@@ -232,8 +253,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "vdbcache",
+        "product_base_type": "vdbcache",
         "identifier": "",
+        "product_type_items": [],
         "label": "VDB Volumes",
         "icon": "fa.cloud",
         "default_variants": [],
@@ -247,8 +269,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "matchmove",
+        "product_base_type": "matchmove",
         "identifier": "",
+        "product_type_items": [],
         "label": "Matchmove",
         "icon": "fa.empire",
         "default_variants": [
@@ -264,8 +287,9 @@ DEFAULT_SIMPLE_CREATORS = [
         "extensions": []
     },
     {
-        "product_type": "rig",
+        "product_base_type": "rig",
         "identifier": "",
+        "product_type_items": [],
         "label": "Rig",
         "icon": "fa.wheelchair",
         "default_variants": [],
@@ -282,8 +306,9 @@ DEFAULT_SIMPLE_CREATORS = [
         ]
     },
     {
-        "product_type": "simpleUnrealTexture",
+        "product_base_type": "simpleUnrealTexture",
         "identifier": "",
+        "product_type_items": [],
         "label": "Simple UE texture",
         "icon": "fa.image",
         "default_variants": [],
@@ -295,8 +320,9 @@ DEFAULT_SIMPLE_CREATORS = [
         "extensions": []
     },
     {
-        "product_type": "audio",
+        "product_base_type": "audio",
         "identifier": "",
+        "product_type_items": [],
         "label": "Audio ",
         "icon": "fa5s.file-audio",
         "default_variants": [


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
All create plugins do have product base type as main "pipeline" type. Also added product type as an alias, but only for few of the create plugins.

## Testing notes:
For all steps make sure to upload the addon to server and use ayon-core 1.8.x .

### Settings based create plugins
1. Define product types for a create plugin that does support it (e.g. simple create plugins).
2. Create an instance with the product type.
3. Product name should use the product type in name (if template defines that).
4. Publish the instance.
5. Loader tool should show the product type and product base type in UI

### Editorials
I have no idea how to test. I was not able to find out how to be able to add product types, it will probably require someone who knows the workflow and logic to add/change it. This PR changed to use product base types and it just work as it did before.
- [ ] Simple Editorial
- [x] Advanced Editorial

### Batch Mov
As far as I understand, it should just work.
- [x] Batch Movies

### CSV Ingest
No idea how that works and how much does it affect the output. As far as I understood csv ingest already does support product base type support (to some dregree) and product types are defined by the csv data, so there probably is not an option to select different product type. So I guess it should work.
- [x] CSV Ingest