### PR TITLE
YN-0447: Enable promised context for tasks during CSV ingestion

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -660,10 +660,11 @@ configuration in project settings.
             )
             if task_entity is None:
                 missing_tasks.add(f"{folder_path}/{task_name}")
+                product_item.has_promised_context = True
             else:
                 product_item.task_type = task_entity["taskType"]
 
-        if missing_tasks:
+        if missing_tasks and not folder_creation_config["enabled"]:
             ending = "" if len(missing_tasks) == 1 else "s"
             joined_paths = "\n".join(sorted(missing_tasks))
             raise CreatorError(

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
@@ -55,8 +55,6 @@ class CollectCSVIngestInstancesData(
                 if "frameEnd" in repre_data:
                     frame_end = repre_data["frameEnd"]
 
-            self.log.debug(pformat(repre_data))
-
             instance.data["representations"].append(repre_data)
 
         if frame_start is not None and frame_end is not None:

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
@@ -50,9 +50,8 @@ class CollectCSVIngestInstancesData(
                 repre_data.get("tags") and
                 "review" in repre_data.get("tags", [])
             ):
-                if "frameStart" in repre_data:
+                if "frameStart" in repre_data and "frameEnd" in repre_data:
                     frame_start = repre_data["frameStart"]
-                if "frameEnd" in repre_data:
                     frame_end = repre_data["frameEnd"]
 
             instance.data["representations"].append(repre_data)

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
@@ -60,5 +60,3 @@ class CollectCSVIngestInstancesData(
         if frame_start is not None and frame_end is not None:
             instance.data["frameStart"] = frame_start
             instance.data["frameEnd"] = frame_end
-
-        self.log.debug(pformat(instance.data))

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
@@ -22,6 +22,8 @@ class CollectCSVIngestInstancesData(
         prepared_repres_data_items = instance.data[
             "prepared_data_for_repres"]
 
+        frame_start = None
+        frame_end = None
         for prep_repre_data in prepared_repres_data_items:
             type = prep_repre_data["type"]
             colorspace = prep_repre_data["colorspace"]
@@ -44,4 +46,21 @@ class CollectCSVIngestInstancesData(
                 # thumbnails should be skipped
                 pass
 
+            if (
+                repre_data.get("tags") and
+                "review" in repre_data.get("tags", [])
+            ):
+                if "frameStart" in repre_data:
+                    frame_start = repre_data["frameStart"]
+                if "frameEnd" in repre_data:
+                    frame_end = repre_data["frameEnd"]
+
+            self.log.debug(pformat(repre_data))
+
             instance.data["representations"].append(repre_data)
+
+        if frame_start is not None and frame_end is not None:
+            instance.data["frameStart"] = frame_start
+            instance.data["frameEnd"] = frame_end
+
+        self.log.debug(pformat(instance.data))


### PR DESCRIPTION
## Changelog Description
Tasks can now leverage promised context during CSV ingestion, allowing the publisher to proceed even when task entities haven't been created yet. Frame metadata for review representations is properly propagated to instance data for downstream processing.

## Additional info
- **CSV Create Plugin**: When task entities are missing, `has_promised_context` is now set to `True` on the product item, enabling deferred task validation during folder creation workflows.
- **Publish Collector**: Frame start/end metadata from review-tagged representations is extracted and populated to instance data, ensuring frame information flows through the publish pipeline.
- **Validation Logic**: Missing tasks no longer trigger immediate errors when folder creation is enabled, allowing the workflow to proceed with promised contexts.

## Testing notes:
1. Perform CSV ingest with missing task entities and folder creation enabled—verify publisher proceeds without errors
2. Ingest CSV with review representations containing frame metadata—confirm `frameStart` and `frameEnd` appear in instance data
3. Verify promised context resolves correctly during the publish stage
4. Test with folder creation disabled—ensure missing tasks still raise appropriate errors

## Dependency
Close [YN-0447](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=task&id=656e3770fb9b11f09a48b5f02dabbdea)
continuation of https://github.com/ynput/ayon-traypublisher/issues/126