### PR TITLE
Add reviewable representation support for online product type

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_online.py
+++ b/client/ayon_traypublisher/plugins/create/create_online.py
@@ -77,7 +77,7 @@ class OnlineCreator(TrayPublishCreator):
     def get_pre_create_attr_defs(self):
         return [
             FileDef(
-                "representation_file",
+                "representation_files",
                 folders=False,
                 extensions=self.extensions,
                 allow_sequences=True,

--- a/client/ayon_traypublisher/plugins/create/create_online.py
+++ b/client/ayon_traypublisher/plugins/create/create_online.py
@@ -7,12 +7,15 @@ exists under selected folder.
 """
 from pathlib import Path
 
-from ayon_core.lib.attribute_definitions import FileDef, BoolDef
+from ayon_core.lib.attribute_definitions import FileDef
 from ayon_core.pipeline import (
     CreatedInstance,
     CreatorError
 )
-from ayon_traypublisher.api.plugin import TrayPublishCreator
+from ayon_traypublisher.api.plugin import (
+    TrayPublishCreator,
+    REVIEW_EXTENSIONS
+)
 
 
 class OnlineCreator(TrayPublishCreator):
@@ -81,10 +84,14 @@ class OnlineCreator(TrayPublishCreator):
                 single_item=True,
                 label="Representation",
             ),
-            BoolDef(
-                "add_review_family",
-                default=True,
-                label="Review"
+            FileDef(
+                "reviewable",
+                folders=False,
+                extensions=REVIEW_EXTENSIONS,
+                allow_sequences=True,
+                single_item=True,
+                label="Reviewable representations",
+                extensions_label="Single reviewable item"
             )
         ]
 

--- a/client/ayon_traypublisher/plugins/create/create_online.py
+++ b/client/ayon_traypublisher/plugins/create/create_online.py
@@ -42,7 +42,7 @@ class OnlineCreator(TrayPublishCreator):
         return "fa.file"
 
     def create(self, product_name, instance_data, pre_create_data):
-        repr_file = pre_create_data.get("representation_file")
+        repr_file = pre_create_data.get("representation_files")
         if not repr_file:
             raise CreatorError("No files specified")
 

--- a/client/ayon_traypublisher/plugins/publish/collect_online_file.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_online_file.py
@@ -1,44 +1,21 @@
 # -*- coding: utf-8 -*-
 import pyblish.api
-import os
 
 
 class CollectOnlineFile(pyblish.api.InstancePlugin):
     """Collect online file and retain its file name."""
     label = "Collect Online File"
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.495
     families = ["online"]
     hosts = ["traypublisher"]
 
-    def process(self, instance):
-        creator_attributes: dict = instance.data["creator_attributes"]
+    def process(self, instance: pyblish.api.Instance):
+        if instance.data.get("creator_identifier") != "io.ayon.creators.traypublisher.online":
+            return
 
-        review = creator_attributes["add_review_family"]
-        instance.data["review"] = review
-        if "review" not in instance.data["families"]:
-            instance.data["families"].append("review")
-        self.log.info(f"Adding review: {review}")
+        instance.data["families"].append("simple.instance")
 
-        filepath_items = creator_attributes["representation_file"]
-        if not isinstance(filepath_items, list):
-            filepath_items = [filepath_items]
-
-        for filepath_item in filepath_items:
-            # Skip if filepath item does not have filenames
-            filenames = filepath_item["filenames"]
-            if not filenames:
-                continue
-
-            ext = os.path.splitext(filenames[0])[1].lstrip(".")
-            if len(filenames) == 1:
-                filenames = filenames[0]
-
-            instance.data["representations"].append(
-                {
-                    "name": ext,
-                    "ext": ext,
-                    "files": filenames,
-                    "stagingDir": filepath_item["directory"],
-                    "tags": ["review"] if review else []
-                }
-            )
+        creator_attributes = instance.data["creator_attributes"]
+        filepath_item = creator_attributes.pop("representation_file")
+        # Pass the item as 'representation_files' for simple instances collector
+        creator_attributes["representation_files"] = [filepath_item]

--- a/client/ayon_traypublisher/plugins/publish/collect_online_file.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_online_file.py
@@ -14,8 +14,3 @@ class CollectOnlineFile(pyblish.api.InstancePlugin):
             return
 
         instance.data["families"].append("simple.instance")
-
-        creator_attributes = instance.data["creator_attributes"]
-        filepath_item = creator_attributes.pop("representation_file")
-        # Pass the item as 'representation_files' for simple instances collector
-        creator_attributes["representation_files"] = [filepath_item]

--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -23,7 +23,7 @@ class CollectSettingsSimpleInstances(pyblish.api.ContextPlugin):
 
     def process(self, context):
         for instance in context:
-            if instance.data.get("setting_creator"):
+            if instance.data.get("settings_creator"):
                 instance.data["families"].append("simple.instance")
 
 

--- a/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_simple_instances.py
@@ -9,8 +9,26 @@ from ayon_core.lib import transcoding
 from ayon_core.pipeline import PublishError
 
 
-class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
-    """Collect data for instances created by settings creators.
+class CollectSettingsSimpleInstances(pyblish.api.ContextPlugin):
+    """Mark instances created by settings creators with the simple.instance family.
+
+    This context plugin identifies instances that were created by settings
+    creators and tags them with the "simple.instance" family for further
+    processing by downstream plugins.
+    """
+
+    label = "Collect Settings Simple Instances"
+    order = pyblish.api.CollectorOrder - 0.495
+    hosts = ["traypublisher"]
+
+    def process(self, context):
+        for instance in context:
+            if instance.data.get("setting_creator"):
+                instance.data["families"].append("simple.instance")
+
+
+class CollectSimpleInstanceRepresentations(pyblish.api.InstancePlugin):
+    """Collect data for instances which have "simple.instance" as families.
 
     Plugin create representations for simple instances based
     on 'representation_files' attribute stored on instance data.
@@ -31,15 +49,12 @@ class CollectSettingsSimpleInstances(pyblish.api.InstancePlugin):
     each created representation has it's own staging dir.
     """
 
-    label = "Collect Settings Simple Instances"
+    label = "Collect Simple Instance Representations"
     order = pyblish.api.CollectorOrder - 0.49
-
+    families = ["simple.instance"]
     hosts = ["traypublisher"]
 
     def process(self, instance):
-        if not instance.data.get("settings_creator"):
-            return
-
         instance_label = instance.data["name"]
         # Create instance's staging dir in temp
         tmp_folder = tempfile.mkdtemp(prefix="traypublisher_")


### PR DESCRIPTION
## Changelog Description
This PR is to add reviewable representation support for online product type so that it is allowed to produce mp4 from image sequences.
Resolve https://github.com/ynput/ayon-traypublisher/issues/78#event-24073430431

## Additional review information
Should we integrate online product type being part of the settingCreator instead?(Out of curiosity to ask although I saw it is using originalBaseName as product name instead)

## Testing notes:
1. Create Online with sequences filled in representation and reviewable representation
2. Publish