### PR TITLE
YN-0661: Fix promised context inheritance in editorial and CSV creators

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -288,6 +288,12 @@ configuration in project settings.
             )
         ]
 
+    def collect_instances(self):
+        super().collect_instances()
+        for instance in self.create_context.instances:
+            if instance.creator_identifier == self.identifier:
+                instance.transient_data["has_promised_context"] = True
+
     def get_pre_create_attr_defs(self):
         """Creating pre-create attributes at creator plugin.
 

--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -128,6 +128,12 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
         return new_instance
 
+    def collect_instances(self):
+        super().collect_instances()
+        for instance in self.create_context.instances:
+            if instance.creator_identifier == self.identifier:
+                instance.transient_data["has_promised_context"] = True
+
     def get_instance_attr_defs(self):
         return [
             BoolDef(
@@ -933,7 +939,8 @@ or updating already created. Publishing will create OTIO file.
                 creator_identifier]
 
             # Create instance in creator context
-            editorial_clip_creator.create(instance_data)
+            c_instance = editorial_clip_creator.create(instance_data)
+            c_instance.transient_data["has_promised_context"] = True
 
     def _extract_version_from_files(self, representations):
         """Extract version information from files
@@ -985,6 +992,7 @@ or updating already created. Publishing will create OTIO file.
         c_instance = self.create_context.creators["editorial_shot_advanced"].create(
             instance_data
         )
+        c_instance.transient_data["has_promised_context"] = True
         parenting_data.update(
             {
                 "instance_label": label,
@@ -1115,8 +1123,9 @@ or updating already created. Publishing will create OTIO file.
         }
         # update base instance data with context data
         # and also update creator attributes with context data
-        creator_attributes["folderPath"] = shot_metadata.pop("folderPath")
-        base_instance_data["folderPath"] = parent_folder_path
+        shot_target_folder_path = shot_metadata.pop("folderPath")
+        creator_attributes["folderPath"] = shot_target_folder_path
+        base_instance_data["folderPath"] = shot_target_folder_path
 
         # add creator attributes to shared instance data
         base_instance_data["creator_attributes"] = creator_attributes

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -120,6 +120,12 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
         return new_instance
 
+    def collect_instances(self):
+        super().collect_instances()
+        for instance in self.create_context.instances:
+            if instance.creator_identifier == self.identifier:
+                instance.transient_data["has_promised_context"] = True
+
     def get_attr_defs_for_instance(self, instance):
         parent_instance = instance.creator_attributes.get("parent_instance")
         return [
@@ -603,6 +609,7 @@ or updating already created. Publishing will create OTIO file.
                 "instance_label": label,
                 "instance_id": c_instance.data["instance_id"]
             })
+            c_instance.transient_data["has_promised_context"] = True
         else:
             # add review family if defined
             instance_data.update({
@@ -619,6 +626,7 @@ or updating already created. Publishing will create OTIO file.
                 creator_identifier]
             c_instance = editorial_clip_creator.create(
                 instance_data)
+            c_instance.transient_data["has_promised_context"] = True
 
         return c_instance
 
@@ -741,8 +749,9 @@ or updating already created. Publishing will create OTIO file.
         }
         # update base instance data with context data
         # and also update creator attributes with context data
-        creator_attributes["folderPath"] = shot_metadata.pop("folderPath")
-        base_instance_data["folderPath"] = parent_folder_path
+        shot_target_folder_path = shot_metadata.pop("folderPath")
+        creator_attributes["folderPath"] = shot_target_folder_path
+        base_instance_data["folderPath"] = shot_target_folder_path
 
         # add creator attributes to shared instance data
         base_instance_data["creator_attributes"] = creator_attributes

--- a/client/ayon_traypublisher/plugins/publish/collect_clip_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_clip_instances.py
@@ -6,7 +6,7 @@ class CollectClipInstance(pyblish.api.InstancePlugin):
     """Collect clip instances and resolve its parent"""
 
     label = "Collect Clip Instances"
-    order = pyblish.api.CollectorOrder - 0.081
+    order = pyblish.api.CollectorOrder - 0.44
 
     hosts = ["traypublisher"]
     families = [

--- a/client/ayon_traypublisher/plugins/publish/collect_editorial_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_editorial_instances.py
@@ -8,7 +8,7 @@ class CollectEditorialInstance(pyblish.api.InstancePlugin):
     """Collect data for instances created by settings creators."""
 
     label = "Collect Editorial Instances"
-    order = pyblish.api.CollectorOrder - 0.1
+    order = pyblish.api.CollectorOrder - 0.46
 
     hosts = ["traypublisher"]
     families = ["editorial"]

--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -11,7 +11,7 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
     """
 
     label = "Collect Shot Instances"
-    order = pyblish.api.CollectorOrder - 0.09
+    order = pyblish.api.CollectorOrder - 0.45
 
     hosts = ["traypublisher"]
     families = ["shot"]


### PR DESCRIPTION
## Changelog Description
Fixed promised context propagation for instances created by editorial and CSV ingesting creators. Instances now correctly inherit promised context flags and folder paths, ensuring consistency across the creator hierarchy.

## Additional Info
The fix implements three key changes:

1. **Context Flag Propagation**: Added `collect_instances()` override in editorial advanced/simple and CSV ingest creators to mark instances with `has_promised_context = True`.

2. **Folder Path Consistency**: Fixed folder path assignment in editorial creators to use the same `shot_target_folder_path` for both creator attributes and base instance data, eliminating discrepancies between parent and child instances.

3. **Collector Order Adjustment**: Reordered collector plugins to ensure editorial instances are processed in correct sequence (0.46, 0.45, 0.44) before dependent collectors.

## Testing Notes
1. Create editorial clip/shot instances with promised context metadata
2. Verify folder paths match between parent and child instances
3. Confirm CSV ingest instances properly inherit context flags
4. Test publish pipeline respects instance hierarchy ordering

## Dependency
Close [YN-0661]( https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=3ef60c2034ea11f1b0b1e32e73eb32ec)
