### PR TITLE
CSV Ingest: Initialize promised context data for missing tasks

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -668,6 +668,12 @@ configuration in project settings.
             if task_entity is None:
                 missing_tasks.add(f"{folder_path}/{task_name}")
                 product_item.has_promised_context = True
+                product_item.task_type = None
+                product_item.parents = self._compute_parents_data(
+                    project_name,
+                    product_item,
+                    preset_data,
+                )
             else:
                 product_item.task_type = task_entity["taskType"]
 


### PR DESCRIPTION
## Changelog Description
CSV ingest was not covering the case where Folder was existing but Task inside was not. This is now creating additional task in the folder. 

## Additional review information
We were not passing correctly promissed context for missing task. 

## Testing notes:
1. ingest csv file with existing folder but missing task
2. all should work file now. 