### PR TITLE
YN-0685: Add preset parameter to CSV ingest CLI

### DIFF
--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -96,7 +96,7 @@ class TrayPublishAddon(
             type=str,
             required=True
         ).option(
-            "--preset-name",
+            "--preset",
             help="Name of the preset to use for the CSV ingest",
             type=str,
             required=True
@@ -177,7 +177,7 @@ class TrayPublishAddon(
     def _cli_ingest_csv(
         self,
         filepath,
-        preset_name,
+        preset,
         project,
         folder_path,
         task,
@@ -198,8 +198,8 @@ class TrayPublishAddon(
             if con.is_service_user():
                 con.set_default_service_username(username)
 
-        if not preset_name:
-            raise ValueError("preset_name is required")
+        if not preset:
+            raise ValueError("preset is required")
 
         # use Path to check if csv_filepath exists
         if not Path(filepath).exists():
@@ -207,7 +207,7 @@ class TrayPublishAddon(
 
         csvpublish(
             filepath,
-            preset_name,
+            preset,
             project,
             folder_path,
             task,

--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -96,6 +96,11 @@ class TrayPublishAddon(
             type=str,
             required=True
         ).option(
+            "--preset-name",
+            help="Name of the preset to use for the CSV ingest",
+            type=str,
+            required=True
+        ).option(
             "--project",
             help="Project name in which the context will be used",
             type=str,
@@ -172,6 +177,7 @@ class TrayPublishAddon(
     def _cli_ingest_csv(
         self,
         filepath,
+        preset_name,
         project,
         folder_path,
         task,
@@ -192,12 +198,16 @@ class TrayPublishAddon(
             if con.is_service_user():
                 con.set_default_service_username(username)
 
+        if not preset_name:
+            raise ValueError("preset_name is required")
+
         # use Path to check if csv_filepath exists
         if not Path(filepath).exists():
             raise FileNotFoundError(f"File {filepath} does not exist.")
 
         csvpublish(
             filepath,
+            preset_name,
             project,
             folder_path,
             task,

--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -12,6 +12,7 @@ from ayon_traypublisher.api import TrayPublisherHost
 
 def csvpublish(
     filepath,
+    preset_name,
     project_name,
     folder_path,
     task_name=None,
@@ -21,6 +22,7 @@ def csvpublish(
 
     Args:
         filepath (str): Path to CSV file.
+        preset_name (str): Name of the preset to use.
         project_name (str): Project name.
         folder_path (str): Folder path.
         task_name (Optional[str]): Task name.
@@ -37,6 +39,7 @@ def csvpublish(
     file_field = FileDefItem.from_paths([filepath], False).pop().to_dict()
     precreate_data = {
         "csv_filepath_data": file_field,
+        "preset": preset_name,
     }
 
     # create context initialization

--- a/client/ayon_traypublisher/csv_publish.py
+++ b/client/ayon_traypublisher/csv_publish.py
@@ -12,7 +12,7 @@ from ayon_traypublisher.api import TrayPublisherHost
 
 def csvpublish(
     filepath,
-    preset_name,
+    preset,
     project_name,
     folder_path,
     task_name=None,
@@ -22,7 +22,7 @@ def csvpublish(
 
     Args:
         filepath (str): Path to CSV file.
-        preset_name (str): Name of the preset to use.
+        preset (str): Name of the preset to use.
         project_name (str): Project name.
         folder_path (str): Folder path.
         task_name (Optional[str]): Task name.
@@ -39,7 +39,7 @@ def csvpublish(
     file_field = FileDefItem.from_paths([filepath], False).pop().to_dict()
     precreate_data = {
         "csv_filepath_data": file_field,
-        "preset": preset_name,
+        "preset": preset,
     }
 
     # create context initialization


### PR DESCRIPTION
## Changelog Description
Added `--preset` parameter to CSV ingest CLI command. This enables users to specify which preset configuration to use when ingesting CSV data, improving workflow flexibility and reducing manual preset selection steps.

## Additional info
The changes add a required `--preset` CLI option to the `csv-ingest` command, which is propagated through the `_cli_ingest_csv` method and passed to the `csvpublish` function. The preset name is stored in the precreate data dictionary as `"preset"` key and validates that the parameter is provided before processing.

Modified files:
- `addon.py`: Added CLI option definition and parameter handling with validation
- `csv_publish.py`: Updated function signature and documentation to accept preset_name parameter

## Testing notes:
testing internal data https://drive.google.com/open?id=1SNWZHpx8ms6FQRTgd6fp84Rju58BObVU&usp=drive_fs
1. Run CSV ingest command with `--preset` parameter: `ayon-traypublisher csv-ingest --filepath <path> --preset <name> --project <project> --folder-path <path>`
2. Verify command fails gracefully if `--preset` is not provided
3. Confirm preset configuration is correctly applied during CSV data ingestion
4. Test with various preset names to ensure proper propagation through the pipeline

## Dependency
[YN-0685](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=task&id=21fd8d503e4011f1a4fdb7d03da6a1f7)

closes #140