### PR TITLE
Add CSV ingest prevalidation report plugins

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -1205,6 +1205,11 @@ configuration in project settings.
             if product_item.has_promised_context:
                 new_instance.transient_data["has_promised_context"] = True
 
+            # add prevalidation preset to instance transient data
+            if preset_data.get("prevalidation"):
+                new_instance.data["prevalidation"] = \
+                    preset_data["prevalidation"]
+
             instances.append(new_instance)
 
         return instances

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -1,8 +1,8 @@
-from pprint import pformat
 import pyblish.api
 from ayon_core.pipeline.publish import (
     OptionalPyblishPluginMixin,
 )
+
 
 class CollectCSVIngestPrevalidationReport(
     OptionalPyblishPluginMixin,

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -1,0 +1,61 @@
+from pprint import pformat
+import pyblish.api
+
+
+class CollectCSVIngestPrevalidationReport(pyblish.api.ContextPlugin):
+    """Collect CSV Ingest prevalidation report data from instances.
+    """
+
+    label = "Collect CSV Ingest instances data"
+    order = pyblish.api.CollectorOrder + 0.5
+    hosts = ["traypublisher"]
+    families = ["csv_ingest"]
+
+    settings_category = "traypublisher"
+
+    validators = []
+
+    def process(self, context):
+
+        if "duplicate_versions" in self.validators:
+            report_data: dict[str, list] = context.data.setdefault(
+                "csvPrevalidationReportData", {})
+            report_rows = self._duplicate_version_instances(context)
+            if report_rows:
+                report_data.update({
+                    "duplicate_versions": report_rows
+                })
+        else:
+            for instance in context:
+                self.log.debug(pformat(instance.data))
+
+    def _duplicate_version_instances(self, context: pyblish.api.Context):
+        """Find duplicate version instances in the context."""
+        report_rows = []
+        duplicate_instances = []
+        seen_versions = set()
+
+        for instance in context:
+            instance_context_data = {
+                "folderPath": instance.data.get("folderPath"),
+                "productName": instance.data.get("productName"),
+                "productBaseType": instance.data.get("productBaseType"),
+                "productType": instance.data.get("productType"),
+                "version": instance.data.get("version"),
+            }
+            if instance_context_data not in seen_versions:
+                seen_versions.add(instance_context_data)
+            else:
+                instance.data["duplicateMsg"] = (
+                    "Duplicate version found for context: "
+                    f"{instance_context_data}"
+                )
+                duplicate_instances.append(instance)
+
+        # if any duplicate instances are found then remove it from context
+        if duplicate_instances:
+            for instance in duplicate_instances:
+                report_rows.append(instance.data["duplicateMsg"])
+                context.remove(instance)
+
+        return report_rows

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -6,7 +6,7 @@ from ayon_core.pipeline.publish import (
 
 class CollectCSVIngestPrevalidationReport(
     OptionalPyblishPluginMixin,
-    pyblish.api.ContextPlugin
+    pyblish.api.InstancePlugin
 ):
     """Collect CSV Ingest prevalidation report data from instances.
     """
@@ -18,152 +18,155 @@ class CollectCSVIngestPrevalidationReport(
 
     settings_category = "traypublisher"
 
-    validators = []
+    def process(self, instance):
 
-    def process(self, context):
+        publish_attributes = instance.data["publish_attributes"]
+        prevalidation = instance.data["prevalidation"]
+        if not prevalidation["enabled"]:
+            return
 
-        if "existing_versions" in self.validators:
-            report_data: dict[str, list] = context.data.setdefault(
+        validators = prevalidation.get("validators", [])
+        config = prevalidation.get("config")
+
+        failing_validation = False
+        if "existing_versions" in validators:
+            report_data: dict[str, list] = instance.context.data.setdefault(
                 "csvPrevalidationReportData", {})
-            report_rows = self._existing_version_check(context)
-            if report_rows:
-                report_data.update({
-                    "Existing Versions Validation": report_rows
-                })
-        if "wrong_framerange" in self.validators:
-            report_data: dict[str, list] = context.data.setdefault(
-                "csvPrevalidationReportData", {})
-            report_rows = self._wrong_framerange_check(context)
-            if report_rows:
-                report_data.update({
-                    "Wrong Frame Range": report_rows
-                })
-
-    def _existing_version_check(self, context: pyblish.api.Context):
-        """Find duplicate version instances in the context."""
-        report_rows = []
-        duplicate_instances = []
-
-        for instance in context:
-            # Skip the instance if is not active by data on the instance
-            if not self.is_active(instance.data):
-                continue
-
-            instance_context_data = {
-                "folderPath": instance.data.get("folderPath"),
-                "productName": instance.data.get("productName"),
-                "productBaseType": instance.data.get("productBaseType"),
-                "productType": instance.data.get("productType"),
-                "version": instance.data.get("version"),
-            }
-            version = instance.data.get("version")
-            latest_version = instance.data.get("latestVersion")
-
-            if (
-                latest_version is not None
-                and int(version) <= int(latest_version)
-            ):
-                instance.data["existingVersionMsg"] = (
-                    "Existing version found for context: "
-                    f"{instance_context_data}"
+            report_row = self._existing_version_check(
+                instance)
+            if report_row:
+                existing_rows: list[str] = report_data.setdefault(
+                    "Existing Versions Validation", []
                 )
-                duplicate_instances.append(instance)
+                existing_rows.append(report_row)
+                failing_validation = True
 
-        # if any duplicate instances are found then remove it from context
-        if duplicate_instances:
-            for instance in duplicate_instances:
-                publish_attributes = instance.data["publish_attributes"]
-                report_rows.append(instance.data["existingVersionMsg"])
-                publish_attributes["ValidateExistingVersion"]["active"] = False
-                # context.remove(instance)
+                if "bypass" in config:
+                    publish_attributes[
+                        "ValidateExistingVersion"]["active"] = False
 
-        return report_rows
+        if "wrong_framerange" in validators:
+            report_data: dict[str, list] = instance.context.data.setdefault(
+                "csvPrevalidationReportData", {})
+            report_row = self._wrong_framerange_check(
+                instance)
+            if report_row:
+                wrongrange_rows: list[str] = report_data.setdefault(
+                    "Wrong Frame Range", []
+                )
+                wrongrange_rows.append(report_row)
+                failing_validation = True
 
-    def _wrong_framerange_check(self, context: pyblish.api.Context):
-        """Check for instances with wrong frame range."""
-        report_rows = []
-        wrong_framerange_instances = []
+                if config == "bypass":
+                    publish_attributes[
+                        "ValidateFrameRange"]["active"] = False
 
-        for instance in context:
-            # Skip the instance if is not active by data on the instance
-            if not self.is_active(instance.data):
-                continue
+        # Skip publishing if requested
+        if failing_validation and config == "skip":
+            instance.context.remove(instance)
 
-            # editorial would fail since they might not be in database yet
-            new_hierarchy = instance.data.get("newHierarchyIntegration")
-            if new_hierarchy:
-                self.log.debug("Instance is creating new folder. Skipping.")
-                continue
 
-            # Use attributes from task entity if set, otherwise from folder entity
-            entity = (
-                instance.data.get("taskEntity") or instance.data["folderEntity"]
+    def _existing_version_check(
+        self,
+        instance: pyblish.api.Instance
+    ) -> str:
+        """Find duplicate version instances in the context."""
+
+        # Skip the instance if is not active by data on the instance
+        if not self.is_active(instance.data):
+            return ""
+
+        instance_context_data = {
+            "folderPath": instance.data.get("folderPath"),
+            "productName": instance.data.get("productName"),
+            "productBaseType": instance.data.get("productBaseType"),
+            "productType": instance.data.get("productType"),
+            "version": instance.data.get("version"),
+        }
+        version = instance.data.get("version")
+        latest_version = instance.data.get("latestVersion")
+
+        if (
+            latest_version is not None
+            and int(version) <= int(latest_version)
+        ):
+            return (
+                "Existing version found for context: "
+                f"{instance_context_data}"
             )
-            attributes = entity["attrib"]
-            frame_start = attributes["frameStart"]
-            frame_end = attributes["frameEnd"]
-            handle_start = attributes["handleStart"]
-            handle_end = attributes["handleEnd"]
-            duration = (frame_end - frame_start + 1) + handle_start + handle_end
 
-            if instance.data["productBaseType"] == "csv_ingest_file":
+        return ""
+
+    def _wrong_framerange_check(
+        self,
+        instance: pyblish.api.Instance,
+    ) -> str:
+        """Check for instances with wrong frame range."""
+
+        # Skip the instance if is not active by data on the instance
+        if not self.is_active(instance.data):
+            return ""
+
+        # editorial would fail since they might not be in database yet
+        new_hierarchy = instance.data.get("newHierarchyIntegration")
+        if new_hierarchy:
+            self.log.debug("Instance is creating new folder. Skipping.")
+            return ""
+
+        # Use attributes from task entity if set, otherwise from folder entity
+        entity = (
+            instance.data.get("taskEntity") or instance.data["folderEntity"]
+        )
+        attributes = entity["attrib"]
+        frame_start = attributes["frameStart"]
+        frame_end = attributes["frameEnd"]
+        handle_start = attributes["handleStart"]
+        handle_end = attributes["handleEnd"]
+        duration = (frame_end - frame_start + 1) + handle_start + handle_end
+
+        if instance.data["productBaseType"] == "csv_ingest_file":
+            return ""
+
+        repres = instance.data.get("representations")
+        if not repres:
+            self.log.info("No representations, skipping.")
+            return ""
+
+        for repre in repres:
+            ext = repre['ext'].replace(".", '')
+
+            if not ext or ext.lower() not in {
+                "exr",
+                "dpx",
+                "jpg",
+                "jpeg",
+                "png",
+                "tiff",
+                "tga",
+                "gif",
+                "svg",
+                "sxr"
+            }:
+                self.log.debug("Cannot check for extension {}".format(ext))
                 continue
 
-            repres = instance.data.get("representations")
-            if not repres:
-                self.log.info("No representations, skipping.")
-                return
+            files = repre["files"]
+            if isinstance(files, str):
+                continue
+            frames = len(files)
 
-            for repre in repres:
-                ext = repre['ext'].replace(".", '')
-
-                if not ext or ext.lower() not in {
-                    "exr",
-                    "dpx",
-                    "jpg",
-                    "jpeg",
-                    "png",
-                    "tiff",
-                    "tga",
-                    "gif",
-                    "svg",
-                    "sxr"
-                }:
-                    self.log.debug("Cannot check for extension {}".format(ext))
-                    continue
-
-                files = repre["files"]
-                if isinstance(files, str):
-                    continue
-                frames = len(files)
-
-                if frames != duration:
-                    instance_context_data = {
-                        "folderPath": instance.data.get("folderPath"),
-                        "productName": instance.data.get("productName"),
-                        "productBaseType": instance.data.get("productBaseType"),
-                        "productType": instance.data.get("productType"),
-                        "version": instance.data.get("version"),
-                    }
-                    msg = (
-                        "Instance context: {} - Frame duration from DB:'{}' doesn't match number of files:'{}'"
-                        " Please change frame range for folder/task or limit no. of files"
-                    ).format(instance_context_data, int(duration), frames)
-
-                    wrong_framerange_instances.append(
-                        {
-                            "instance": instance,
-                            "msg": msg
-                        }
-                    )
-
-        if wrong_framerange_instances:
-            for fail_data in wrong_framerange_instances:
-                self.log.debug(f"Wrong frame range instance: {fail_data}")
-                instance = fail_data["instance"]
-                publish_attributes = instance.data["publish_attributes"]
-                report_rows.append(fail_data["msg"])
-                publish_attributes["ValidateFrameRange"]["active"] = False
-                # context.remove(fail_data["instance"])
-
-        return report_rows
+            if frames != duration:
+                instance_context_data = {
+                    "folderPath": instance.data.get("folderPath"),
+                    "productName": instance.data.get("productName"),
+                    "productBaseType": instance.data.get("productBaseType"),
+                    "productType": instance.data.get("productType"),
+                    "version": instance.data.get("version"),
+                }
+                return (
+                    f"Instance context: {instance_context_data} - Frame "
+                    f"duration from DB:'{int(duration)}' doesn't match "
+                    f"number of files:'{frames}' Please change frame "
+                    "range for folder/task or limit no. of files"
+                )
+        return ""

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -1,13 +1,18 @@
 from pprint import pformat
 import pyblish.api
+from ayon_core.pipeline.publish import (
+    OptionalPyblishPluginMixin,
+)
 
-
-class CollectCSVIngestPrevalidationReport(pyblish.api.ContextPlugin):
+class CollectCSVIngestPrevalidationReport(
+    OptionalPyblishPluginMixin,
+    pyblish.api.ContextPlugin
+):
     """Collect CSV Ingest prevalidation report data from instances.
     """
 
-    label = "Collect CSV Ingest instances data"
-    order = pyblish.api.CollectorOrder + 0.5
+    label = "Collect CSV Ingest Prevalidation Report"
+    order = pyblish.api.CollectorOrder + 0.499
     hosts = ["traypublisher"]
     families = ["csv_ingest"]
 
@@ -17,25 +22,33 @@ class CollectCSVIngestPrevalidationReport(pyblish.api.ContextPlugin):
 
     def process(self, context):
 
-        if "duplicate_versions" in self.validators:
+        if "existing_versions" in self.validators:
             report_data: dict[str, list] = context.data.setdefault(
                 "csvPrevalidationReportData", {})
-            report_rows = self._duplicate_version_instances(context)
+            report_rows = self._existing_version_check(context)
             if report_rows:
                 report_data.update({
-                    "duplicate_versions": report_rows
+                    "Existing Versions Validation": report_rows
                 })
-        else:
-            for instance in context:
-                self.log.debug(pformat(instance.data))
+        if "wrong_framerange" in self.validators:
+            report_data: dict[str, list] = context.data.setdefault(
+                "csvPrevalidationReportData", {})
+            report_rows = self._wrong_framerange_check(context)
+            if report_rows:
+                report_data.update({
+                    "Wrong Frame Range": report_rows
+                })
 
-    def _duplicate_version_instances(self, context: pyblish.api.Context):
+    def _existing_version_check(self, context: pyblish.api.Context):
         """Find duplicate version instances in the context."""
         report_rows = []
         duplicate_instances = []
-        seen_versions = set()
 
         for instance in context:
+            # Skip the instance if is not active by data on the instance
+            if not self.is_active(instance.data):
+                continue
+
             instance_context_data = {
                 "folderPath": instance.data.get("folderPath"),
                 "productName": instance.data.get("productName"),
@@ -43,11 +56,15 @@ class CollectCSVIngestPrevalidationReport(pyblish.api.ContextPlugin):
                 "productType": instance.data.get("productType"),
                 "version": instance.data.get("version"),
             }
-            if instance_context_data not in seen_versions:
-                seen_versions.add(instance_context_data)
-            else:
-                instance.data["duplicateMsg"] = (
-                    "Duplicate version found for context: "
+            version = instance.data.get("version")
+            latest_version = instance.data.get("latestVersion")
+
+            if (
+                latest_version is not None
+                and int(version) <= int(latest_version)
+            ):
+                instance.data["existingVersionMsg"] = (
+                    "Existing version found for context: "
                     f"{instance_context_data}"
                 )
                 duplicate_instances.append(instance)
@@ -55,7 +72,98 @@ class CollectCSVIngestPrevalidationReport(pyblish.api.ContextPlugin):
         # if any duplicate instances are found then remove it from context
         if duplicate_instances:
             for instance in duplicate_instances:
-                report_rows.append(instance.data["duplicateMsg"])
-                context.remove(instance)
+                publish_attributes = instance.data["publish_attributes"]
+                report_rows.append(instance.data["existingVersionMsg"])
+                publish_attributes["ValidateExistingVersion"]["active"] = False
+                # context.remove(instance)
+
+        return report_rows
+
+    def _wrong_framerange_check(self, context: pyblish.api.Context):
+        """Check for instances with wrong frame range."""
+        report_rows = []
+        wrong_framerange_instances = []
+
+        for instance in context:
+            # Skip the instance if is not active by data on the instance
+            if not self.is_active(instance.data):
+                continue
+
+            # editorial would fail since they might not be in database yet
+            new_hierarchy = instance.data.get("newHierarchyIntegration")
+            if new_hierarchy:
+                self.log.debug("Instance is creating new folder. Skipping.")
+                continue
+
+            # Use attributes from task entity if set, otherwise from folder entity
+            entity = (
+                instance.data.get("taskEntity") or instance.data["folderEntity"]
+            )
+            attributes = entity["attrib"]
+            frame_start = attributes["frameStart"]
+            frame_end = attributes["frameEnd"]
+            handle_start = attributes["handleStart"]
+            handle_end = attributes["handleEnd"]
+            duration = (frame_end - frame_start + 1) + handle_start + handle_end
+
+            if instance.data["productBaseType"] == "csv_ingest_file":
+                continue
+
+            repres = instance.data.get("representations")
+            if not repres:
+                self.log.info("No representations, skipping.")
+                return
+
+            for repre in repres:
+                ext = repre['ext'].replace(".", '')
+
+                if not ext or ext.lower() not in {
+                    "exr",
+                    "dpx",
+                    "jpg",
+                    "jpeg",
+                    "png",
+                    "tiff",
+                    "tga",
+                    "gif",
+                    "svg",
+                    "sxr"
+                }:
+                    self.log.debug("Cannot check for extension {}".format(ext))
+                    continue
+
+                files = repre["files"]
+                if isinstance(files, str):
+                    continue
+                frames = len(files)
+
+                if frames != duration:
+                    instance_context_data = {
+                        "folderPath": instance.data.get("folderPath"),
+                        "productName": instance.data.get("productName"),
+                        "productBaseType": instance.data.get("productBaseType"),
+                        "productType": instance.data.get("productType"),
+                        "version": instance.data.get("version"),
+                    }
+                    msg = (
+                        "Instance context: {} - Frame duration from DB:'{}' doesn't match number of files:'{}'"
+                        " Please change frame range for folder/task or limit no. of files"
+                    ).format(instance_context_data, int(duration), frames)
+
+                    wrong_framerange_instances.append(
+                        {
+                            "instance": instance,
+                            "msg": msg
+                        }
+                    )
+
+        if wrong_framerange_instances:
+            for fail_data in wrong_framerange_instances:
+                self.log.debug(f"Wrong frame range instance: {fail_data}")
+                instance = fail_data["instance"]
+                publish_attributes = instance.data["publish_attributes"]
+                report_rows.append(fail_data["msg"])
+                publish_attributes["ValidateFrameRange"]["active"] = False
+                # context.remove(fail_data["instance"])
 
         return report_rows

--- a/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
@@ -39,8 +39,8 @@ class ExtractCSVPrevalidationReport(publish.Extractor):
                 # write rows into a simple text file as markdown
                 f.write("## {}\n".format(label))
                 for row in rows:
-                    f.write(", ".join(row) + "\n")
-                f.write("\n")
+                    f.write("- " + row + "\n")
+                f.write("\n\n")
 
 
         self.log.info("CSV report saved: {}".format(csv_report_filepath))

--- a/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
@@ -1,0 +1,46 @@
+import time
+from pathlib import Path
+
+import pyblish.api
+from ayon_core.pipeline import publish
+
+
+class ExtractCSVPrevalidationReport(publish.Extractor):
+    """
+    Extractor CSV ingest prevalidation report
+    """
+
+    label = "Extract CSV file"
+    order = pyblish.api.ExtractorOrder - 0.45
+    families = ["csv_ingest_file"]
+    hosts = ["traypublisher"]
+
+    def process(self, instance):
+        prevalidation_report_data = instance.context.data.get(
+            "csvPrevalidationReportData", {})
+        if not prevalidation_report_data:
+            self.log.info("No prevalidation report data found.")
+            return
+
+        csv_file_data = instance.data["csvFileData"]
+        csv_filename = Path(csv_file_data["filename"])
+        csv_staging_dir = csv_file_data["staging_dir"]
+        csv_filepath = Path(csv_staging_dir) / csv_filename
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+
+        # add _report suffix and change extension to .txt
+        csv_report_filepath = csv_filepath.with_stem(
+            csv_filepath.stem + f"_report_{timestamp}").with_suffix(".txt")
+        self.log.info("CSV report filepath: {}".format(csv_report_filepath))
+
+        # create the report file and save the content to it
+        with csv_report_filepath.open("w", encoding="utf-8") as f:
+            for label, rows in prevalidation_report_data.items():
+                # write rows into a simple text file as markdown
+                f.write("## {}\n".format(label))
+                for row in rows:
+                    f.write(", ".join(row) + "\n")
+                f.write("\n")
+
+
+        self.log.info("CSV report saved: {}".format(csv_report_filepath))

--- a/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/extract_csv_ingest_prevalidation_report.py
@@ -42,5 +42,4 @@ class ExtractCSVPrevalidationReport(publish.Extractor):
                     f.write("- " + row + "\n")
                 f.write("\n\n")
 
-
         self.log.info("CSV report saved: {}".format(csv_report_filepath))

--- a/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -63,28 +63,39 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
             self.log.info("No representations, skipping.")
             return
 
-        first_repre = repres[0]
-        ext = first_repre['ext'].replace(".", '')
+        for repre in repres:
+            ext = repre['ext'].replace(".", '')
 
-        if not ext or ext.lower() not in self.check_extensions:
-            self.log.warning("Cannot check for extension {}".format(ext))
-            return
+            if not ext or ext.lower() not in {
+                "exr",
+                "dpx",
+                "jpg",
+                "jpeg",
+                "png",
+                "tiff",
+                "tga",
+                "gif",
+                "svg",
+                "sxr"
+            }:
+                self.log.debug("Cannot check for extension {}".format(ext))
+                continue
 
-        files = first_repre["files"]
-        if isinstance(files, str):
-            files = [files]
-        frames = len(files)
+            files = repre["files"]
+            if isinstance(files, str):
+                continue
+            frames = len(files)
 
-        msg = (
-            "Frame duration from DB:'{}' doesn't match number of files:'{}'"
-            " Please change frame range for folder/task or limit no. of files"
-        ). format(int(duration), frames)
+            msg = (
+                "Frame duration from DB:'{}' doesn't match number of files:'{}'"
+                " Please change frame range for folder/task or limit no. of files"
+            ). format(int(duration), frames)
 
-        formatting_data = {"duration": duration,
-                           "found": frames}
-        if frames != duration:
-            raise PublishXmlValidationError(self, msg,
-                                            formatting_data=formatting_data)
+            formatting_data = {"duration": duration,
+                            "found": frames}
+            if frames != duration:
+                raise PublishXmlValidationError(self, msg,
+                                                formatting_data=formatting_data)
 
         self.log.debug("Valid ranges expected '{}' - found '{}'".
                        format(int(duration), frames))

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -78,12 +78,41 @@ class ColumnItemModel(BaseSettingsModel):
     )
 
 
-class ColumnConfigModel(BaseSettingsModel):
-    """Column configuration model"""
-    prevalidate_with_report_output: bool = SettingsField(
-        title="Prevalidate with Report",
+def _csv_prevalidators_enum() -> list:
+    return [
+        {"label": "Existing versions", "value": "existing_versions"},
+        {"label": "Wrong framerange", "value": "wrong_framerange"}
+    ]
+
+
+def _csv_prevalidation_config_enum() -> list:
+    return [
+        {"label": "Skip instances from publishing", "value": "skip"},
+        {"label": "Bypass relative validators", "value": "bypass"}
+    ]
+
+
+class PrevalidationModel(BaseSettingsModel):
+    """Prevalidation model."""
+    enabled: bool = SettingsField(
+        title="Enabled",
         default=False
     )
+
+    validators: list[str] = SettingsField(
+        default_factory=list,
+        title="Activated prevalidators",
+        enum_resolver=_csv_prevalidators_enum,
+    )
+    config: str = SettingsField(
+        title="Prevalidation config",
+        default="skip",
+        enum_resolver=_csv_prevalidation_config_enum,
+    )
+
+
+class ColumnConfigModel(BaseSettingsModel):
+    """Column configuration model"""
 
     csv_delimiter: str = SettingsField(
         title="CSV delimiter",
@@ -245,6 +274,10 @@ class IngestCSVPresetModel(BaseSettingsModel):
         "Default",
         title="Name",
     )
+    prevalidation: PrevalidationModel = SettingsField(
+        title="Prevalidation",
+        default_factory=PrevalidationModel
+    )
     columns_config: ColumnConfigModel = SettingsField(
         title="Columns config",
         default_factory=ColumnConfigModel
@@ -338,8 +371,12 @@ DEFAULT_CREATORS = {
         "presets": [
             {
                 "name": "Default",
+                "prevalidation": {
+                    "enabled": True,
+                    "validators": ["existing_versions", "wrong_framerange"],
+                    "config": "skip"
+                },
                 "columns_config": {
-                    "prevalidate_with_report_output": False,
                     "csv_delimiter": ",",
                     "columns": [
                         {

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -80,6 +80,10 @@ class ColumnItemModel(BaseSettingsModel):
 
 class ColumnConfigModel(BaseSettingsModel):
     """Column configuration model"""
+    prevalidate_with_report_output: bool = SettingsField(
+        title="Prevalidate with Report",
+        default=False
+    )
 
     csv_delimiter: str = SettingsField(
         title="CSV delimiter",
@@ -335,6 +339,7 @@ DEFAULT_CREATORS = {
             {
                 "name": "Default",
                 "columns_config": {
+                    "prevalidate_with_report_output": False,
                     "csv_delimiter": ",",
                     "columns": [
                         {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -48,8 +48,8 @@ class ExtractEditorialPckgOutputDefModel(BaseSettingsModel):
 
 class ExtractEditorialPckgConversionModel(BaseSettingsModel):
     """Set output definition if resource files should be converted."""
-    conversion_enabled: bool = SettingsField(True,
-                                             title="Conversion enabled")
+    conversion_enabled: bool = SettingsField(
+        True, title="Conversion enabled")
     output: ExtractEditorialPckgOutputDefModel = SettingsField(
         default_factory=ExtractEditorialPckgOutputDefModel,
         title="Output Definitions",
@@ -58,7 +58,8 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 def _csv_prevalidators_enum() -> list:
     return [
-        {"label": "Duplicate versions", "value": "duplicate_versions"}
+        {"label": "Existing versions", "value": "existing_versions"},
+        {"label": "Wrong framerange", "value": "wrong_framerange"}
     ]
 
 
@@ -98,7 +99,7 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 DEFAULT_PUBLISH_PLUGINS = {
     "CollectCSVIngestPrevalidationReport": {
-        "validators": ["duplicate_versions"]
+        "validators": ["existing_versions", "wrong_framerange"]
     },
     "CollectSequenceFrameData": {
         "enabled": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -56,7 +56,26 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
     )
 
 
+def _csv_prevalidators_enum() -> list:
+    return [
+        {"label": "Duplicate versions", "value": "duplicate_versions"},
+        {"label": "Missing colorspace", "value": "missing_colorspace"}
+    ]
+
+
+class CollectCSVIngestPrevalidationReportModel(BaseSettingsModel):
+    validators: list[str] = SettingsField(
+        default_factory=list,
+        title="Validators",
+        enum_resolver=_csv_prevalidators_enum,
+    )
+
+
 class TrayPublisherPublishPlugins(BaseSettingsModel):
+    CollectCSVIngestPrevalidationReport: CollectCSVIngestPrevalidationReportModel = SettingsField(  # noqa
+        default_factory=CollectCSVIngestPrevalidationReportModel,
+        title="Collect CSV Ingest Prevalidation Report",
+    )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect Original Sequence Frame Data",
@@ -79,6 +98,9 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
+    "CollectCSVIngestPrevalidationReport": {
+        "validators": ["duplicate_versions"]
+    },
     "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -56,24 +56,9 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
     )
 
 
-def _csv_prevalidators_enum() -> list:
-    return [
-        {"label": "Existing versions", "value": "existing_versions"},
-        {"label": "Wrong framerange", "value": "wrong_framerange"}
-    ]
-
-
-class CollectCSVIngestPrevalidationReportModel(BaseSettingsModel):
-    validators: list[str] = SettingsField(
-        default_factory=list,
-        title="Prevalidators",
-        enum_resolver=_csv_prevalidators_enum,
-    )
-
-
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectCSVIngestPrevalidationReport: CollectCSVIngestPrevalidationReportModel = SettingsField(  # noqa
-        default_factory=CollectCSVIngestPrevalidationReportModel,
+    CollectCSVIngestPrevalidationReport: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
         title="Collect CSV Ingest Prevalidation Report",
     )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(
@@ -99,7 +84,9 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 DEFAULT_PUBLISH_PLUGINS = {
     "CollectCSVIngestPrevalidationReport": {
-        "validators": ["existing_versions", "wrong_framerange"]
+        "enabled": True,
+        "optional": True,
+        "active": True
     },
     "CollectSequenceFrameData": {
         "enabled": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -58,15 +58,14 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 def _csv_prevalidators_enum() -> list:
     return [
-        {"label": "Duplicate versions", "value": "duplicate_versions"},
-        {"label": "Missing colorspace", "value": "missing_colorspace"}
+        {"label": "Duplicate versions", "value": "duplicate_versions"}
     ]
 
 
 class CollectCSVIngestPrevalidationReportModel(BaseSettingsModel):
     validators: list[str] = SettingsField(
         default_factory=list,
-        title="Validators",
+        title="Prevalidators",
         enum_resolver=_csv_prevalidators_enum,
     )
 


### PR DESCRIPTION
## Changelog Description
Add collector and extractor plugins for CSV ingest prevalidation reporting. Enables duplicate version detection and configurable validators (existing versions, wrong framerange) via settings with options to skip or bypass failed validations.

## Additional info
Implementation includes:
- **CollectCSVIngestPrevalidationReport** plugin: Collects validation failures (duplicate versions, frame range mismatches) and generates report data
- **ExtractCSVPrevalidationReport** plugin: Exports validation report to timestamped .txt file alongside CSV
- **PrevalidationModel** settings: Configurable validators with skip/bypass actions
- Updated **ValidateFrameRanges** to check all representations instead of first only
- Preset configuration integration in creator settings

## Testing notes:
1. Enable prevalidation in CSV Ingest preset settings
2. Attempt publish with duplicate version - verify instance skipped and report generated
3. Attempt publish with mismatched framerange - verify validation report created
4. Validate report file appears in staging directory with timestamp

## Dependency
Close [YN-0702](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=task&id=a4642710449c11f1a838dd13846dfdf9)
