### PR TITLE
Launch: Pop context env variables if are not passed

### DIFF
--- a/client/ayon_traypublisher/api/main.py
+++ b/client/ayon_traypublisher/api/main.py
@@ -66,8 +66,13 @@ class _LaunchContext:
         os.environ["AYON_PROJECT_NAME"] = self._project_name
         if self._folder_path:
             os.environ["AYON_FOLDER_PATH"] = self._folder_path
+        else:
+            os.environ.pop("AYON_FOLDER_PATH", None)
+
         if self._task_name:
             os.environ["AYON_TASK_NAME"] = self._task_name
+        else:
+            os.environ.pop("AYON_TASK_NAME", None)
 
         ensure_addons_are_process_ready(
             addon_name=self._addon.name,


### PR DESCRIPTION
## Changelog Description
Make sure `AYON_FOLDER_PATH` and `AYON_TASK_NAME` are not set if it is not passed to the launch context.

## Testing notes:
1. Set `AYON_FOLDER_PATH` in console tool to something invalid.
2. Trigger `Publish` in tray,
3. Select project.
4. Create an instance and publish.
5. Collect context entities should not fail.
