### PR TITLE
Make preset argument optional. Defaults to 'Default'

### DIFF
--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -99,7 +99,8 @@ class TrayPublishAddon(
             "--preset",
             help="Name of the preset to use for the CSV ingest",
             type=str,
-            required=True
+            required=False,
+            default="Default",
         ).option(
             "--project",
             help="Project name in which the context will be used",


### PR DESCRIPTION
## Changelog Description
Make `-preset` an optional cli argument, defauting to `Default`

## Additional review information
This new cli argument was added in #142 

## Testing notes:
1. run `ayon-dev addon traypublisher ingestcsv --filepath some_file.csv --preset Default` with and without the preset flag
2. verify the correct preset gets picked up
