### PR TITLE
CSV Ingest: Open CSV file with `utf-8-sig` encoding to avoid issues with BOM in files

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -728,7 +728,7 @@ configuration in project settings.
         ]
 
         # read csv file
-        with open(csv_path, "r") as csv_file:
+        with open(csv_path, "r", encoding="utf-8-sig") as csv_file:
             csv_content = csv_file.read()
 
         # read csv file with DictReader


### PR DESCRIPTION
## Changelog Description

Open CSV file with `utf-8-sig` encoding to avoid issues with BOM in files

## Additional review information

Fix #173 

## Testing notes:

1. Using a CSV file with BOM markers at start of file should load correctly.
