### PR TITLE
CSV ingest: respect enabled validators for prevalidation checks (YN-0904)

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -281,8 +281,8 @@ class CollectCSVIngestPrevalidationReport(
             plugin_name (str): The name of the plugin to check.
 
         Returns:
-            True if the plugin is not set as optional or if it is set
-            but not active.
+            bool: True if the plugin is available an active
+                for the instance.
         """
         # plugin might not be enabled in the publish context
         plugins = instance.context.data["create_context"].publish_plugins

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -269,8 +269,8 @@ class CollectCSVIngestPrevalidationReport(
             None
         )
 
-    @staticmethod
     def _is_instance_plugin_active(
+        self,
         instance: pyblish.api.Instance,
         plugin_name: str
     ) -> bool:

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -281,7 +281,7 @@ class CollectCSVIngestPrevalidationReport(
             plugin_name (str): The name of the plugin to check.
 
         Returns:
-            bool: True if the plugin is available an active
+            bool: True if the plugin is available and active
                 for the instance.
         """
         # plugin might not be enabled in the publish context

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -91,7 +91,7 @@ class CollectCSVIngestPrevalidationReport(
             # we need to make sure the data are available even nothing
             # was added from creator context processed in first pass
             report_data = report_per_csv_ingest[csv_parent_instance_id]
-            plugin_enabled = self._check_enabled_plugins(
+            plugin_enabled = self._is_instance_plugin_active(
                 instance, "ValidateExistingVersion")
             failing_validation = False
             if (
@@ -111,7 +111,7 @@ class CollectCSVIngestPrevalidationReport(
                     existing_rows.append(report_row)
                     failing_validation = True
 
-            plugin_enabled = self._check_enabled_plugins(
+            plugin_enabled = self._is_instance_plugin_active(
                 instance, "ValidateFrameRange")
             if (
                 prevalidation["wrong_framerange"]["mode"] == "ignore"
@@ -270,7 +270,7 @@ class CollectCSVIngestPrevalidationReport(
         )
 
     @staticmethod
-    def _check_enabled_plugins(
+    def _is_instance_plugin_active(
         instance: pyblish.api.Instance,
         plugin_name: str
     ) -> bool:

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -301,6 +301,7 @@ class CollectCSVIngestPrevalidationReport(
         if not plugin.optional:
             return True
 
-        plugin_attributes = instance.data["publish_attributes"].get(
-            plugin_name, {})
-        return plugin_attributes.get("active", False)
+        values = self.get_attr_values_from_data_for_plugin(
+            plugin, instance.data
+        )
+        return values.get("active", False)

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -284,10 +284,23 @@ class CollectCSVIngestPrevalidationReport(
             True if the plugin is not set as optional or if it is set
             but not active.
         """
+        # plugin might not be enabled in the publish context
+        plugins = instance.context.data["create_context"].publish_plugins
+        plugin = next(
+            (
+                pl for pl in plugins
+                if pl.__name__ == plugin_name
+            ),
+            None
+        )
+        if plugin is None:
+            return False
+
+        # plugin might not be set as optional so it will not be added
+        # to publish attributes
+        if not plugin.optional:
+            return True
+
         plugin_attributes = instance.data["publish_attributes"].get(
             plugin_name, {})
-        if not plugin_attributes:
-            # plugin might not be set as optional so it will not be added
-            # to publish attributes
-            return True
         return plugin_attributes.get("active", False)

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -91,9 +91,14 @@ class CollectCSVIngestPrevalidationReport(
             # we need to make sure the data are available even nothing
             # was added from creator context processed in first pass
             report_data = report_per_csv_ingest[csv_parent_instance_id]
-
+            plugin_enabled = self._check_enabled_plugins(
+                instance, "ValidateExistingVersion")
             failing_validation = False
-            if prevalidation["existing_versions"]["mode"] == "ignore":
+            if (
+                prevalidation["existing_versions"]["mode"] == "ignore"
+                and plugin_enabled
+            ):
+                # only check existing version if related validator is enabled
                 version = instance.data.get("version")
                 if version is not None:
                     report_row = self._existing_version_check(instance)
@@ -106,9 +111,14 @@ class CollectCSVIngestPrevalidationReport(
                     existing_rows.append(report_row)
                     failing_validation = True
 
-            if prevalidation["wrong_framerange"]["mode"] == "ignore":
-                report_row = self._wrong_framerange_check(
-                    instance)
+            plugin_enabled = self._check_enabled_plugins(
+                instance, "ValidateFrameRange")
+            if (
+                prevalidation["wrong_framerange"]["mode"] == "ignore"
+                and plugin_enabled
+            ):
+                # only check existing version if related validator is enabled
+                report_row = self._wrong_framerange_check(instance)
                 if report_row:
                     wrongrange_rows: list[str] = report_data.setdefault(
                         "Wrong Frame Range", []
@@ -234,15 +244,16 @@ class CollectCSVIngestPrevalidationReport(
         return ""
 
     @staticmethod
-    def _is_csv_ingest_file_instance(instance):
+    def _is_csv_ingest_file_instance(instance: pyblish.api.Instance) -> bool:
         return "csv_ingest_file" in instance.data.get("families", [])
 
     @staticmethod
-    def _is_csv_ingest_instance(instance):
+    def _is_csv_ingest_instance(instance: pyblish.api.Instance) -> bool:
         return "csv_ingest" in instance.data.get("families", [])
 
     @staticmethod
-    def _get_csv_instance_report(instance):
+    def _get_csv_instance_report(
+            instance: pyblish.api.Instance) -> dict | None:
         return instance.data.get("csvReportData")
 
     @staticmethod
@@ -257,3 +268,26 @@ class CollectCSVIngestPrevalidationReport(
             (p for p in ingest_presets if p["name"] == csv_preset_name),
             None
         )
+
+    @staticmethod
+    def _check_enabled_plugins(
+        instance: pyblish.api.Instance,
+        plugin_name: str
+    ) -> bool:
+        """Check if the plugin is enabled for the given instance.
+
+        Args:
+            instance (pyblish.api.Instance): The instance to check.
+            plugin_name (str): The name of the plugin to check.
+
+        Returns:
+            True if the plugin is not set as optional or if it is set
+            but not active.
+        """
+        plugin_attributes = instance.data["publish_attributes"].get(
+            plugin_name, {})
+        if not plugin_attributes:
+            # plugin might not be set as optional so it will not be added
+            # to publish attributes
+            return True
+        return plugin_attributes.get("active", False)


### PR DESCRIPTION
## Changelog Description
- Only run existing-version and frame-range prevalidation checks when the related validator plugin is enabled. This prevents false-positive validation rows for CSV ingest when validators are intentionally disabled.
- Adds a small helper `_check_enabled_plugins` and type annotations for a few helper methods. Refactors are limited to `collect_csv_ingest_prevalidation_report.py`.

## Additional info
- File changed: `client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py`.
- Key logic: checks for `ValidateExistingVersion` and `ValidateFrameRange` are gated by `_check_enabled_plugins(instance, plugin_name)` so validations only run if the validator is active or not marked optional.
- There is known caveat @BigRoy: In case only single Validator is activated but both cases are having collision, then we are reporting the one which is failing and removing the instance form context anyway. 

## Testing notes:
1. Prepare a CSV ingest with `existing_versions.mode == "ignore"` and the `ValidateExistingVersion` validator disabled — no "Existing Version" report rows should be produced.
2. Enable `ValidateExistingVersion` and re-run — duplicate existing-version rows should appear as before.
3. Repeat steps for `ValidateFrameRange`/`wrong_framerange`.
4. Run the prevalidation path in CI or locally to confirm no regressions.

## Dependency
Close <!--Issue id-->
[#175](https://github.com/ynput/ayon-traypublisher/issues/175)
[<!--YN-0904-->](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=b3884a31efc04cef9008e3b760686e75)
