### PR TITLE
added default_collect_video_framerange setting

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -117,7 +117,8 @@ class CollectTraypublisherVideoFrameData(
     order = pyblish.api.CollectorOrder - 0.25
     hosts = ["traypublisher"]
     optional = True
-
+    settings_category = "traypublisher"
+    default_collect_video_framerange = True
     @classmethod
     def get_attr_defs_for_instance(
         cls, create_context: "CreateContext", instance: "CreatedInstance"  # noqa: F821

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -128,12 +128,7 @@ class CollectTraypublisherVideoFrameData(
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=bool(
-                    create_context.get_current_project_settings()
-                    .get("traypublisher", {})
-                    .get("publish", {})
-                    .get("default_collect_video_framerange", True)
-                ),
+                default=self.default_collect_video_framerange,
                 visible=cls.optional,
             )
         ]

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -128,7 +128,12 @@ class CollectTraypublisherVideoFrameData(
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=True,
+                default=bool(
+                    create_context.get_current_project_settings()
+                    .get("traypublisher", {})
+                    .get("publish", {})
+                    .get("default_collect_video_framerange", True)
+                ),
                 visible=cls.optional,
             )
         ]

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -129,7 +129,7 @@ class CollectTraypublisherVideoFrameData(
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=True
+                default=True,
                 visible=cls.optional,
             )
         ]

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -6,7 +6,6 @@ from typing import Union
 from ayon_core.lib.transcoding import VIDEO_EXTENSIONS
 from ayon_core.lib import get_ffprobe_data, BoolDef
 
-from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 
 import pyblish.api
@@ -118,6 +117,7 @@ class CollectTraypublisherVideoFrameData(
     order = pyblish.api.CollectorOrder - 0.25
     hosts = ["traypublisher"]
     optional = True
+    active = True
     settings_category = "traypublisher"
     
     @classmethod
@@ -131,7 +131,7 @@ class CollectTraypublisherVideoFrameData(
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=create_context.get_current_project_settings()["traypublisher"]["publish"]["CollectVideoData"]["active"],
+                default=cls.active,
                 visible=cls.optional,
             )
         ]
@@ -160,6 +160,9 @@ class CollectTraypublisherVideoFrameData(
         return bool(extensions & _VIDEO_EXTENSIONS)
 
     def process(self, context):
+        if self.optional and not self.active:
+            return
+
         for instance in context:
             data = self.get_attr_values_from_data(instance.data)
             if data.get("collect_video_framerange"):
@@ -167,10 +170,7 @@ class CollectTraypublisherVideoFrameData(
                 instance.data["families"].append("collect.video.framerange")
 
 
-class CollectVideoData(
-    pyblish.api.InstancePlugin,
-    OptionalPyblishPluginMixin
-):
+class CollectVideoData(pyblish.api.InstancePlugin):
     """Collect Original Video Frame Data
 
     If the representation includes video files then set `frameStart` and
@@ -181,8 +181,6 @@ class CollectVideoData(
     order = pyblish.api.CollectorOrder + 0.4905
     label = "Collect Original Video Frame Data"
     families = ["collect.video.framerange"]
-    hosts = ["traypublisher"]
-    optional = True
 
     def process(self, instance):
         if all(

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -129,7 +129,7 @@ class CollectTraypublisherVideoFrameData(
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=self.default_collect_video_framerange,
+                default=True
                 visible=cls.optional,
             )
         ]

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -6,6 +6,7 @@ from typing import Union
 from ayon_core.lib.transcoding import VIDEO_EXTENSIONS
 from ayon_core.lib import get_ffprobe_data, BoolDef
 
+from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_core.pipeline.publish import AYONPyblishPluginMixin
 
 import pyblish.api
@@ -125,11 +126,12 @@ class CollectTraypublisherVideoFrameData(
     ):
         if not cls.instance_supported(create_context, instance):
             return []
+
         return [
             BoolDef(
                 "collect_video_framerange",
                 label="Collect Original Video Frame Data",
-                default=True,
+                default=create_context.get_current_project_settings()["traypublisher"]["publish"]["CollectVideoData"]["active"],
                 visible=cls.optional,
             )
         ]
@@ -165,7 +167,10 @@ class CollectTraypublisherVideoFrameData(
                 instance.data["families"].append("collect.video.framerange")
 
 
-class CollectVideoData(pyblish.api.InstancePlugin):
+class CollectVideoData(
+    pyblish.api.InstancePlugin,
+    OptionalPyblishPluginMixin
+):
     """Collect Original Video Frame Data
 
     If the representation includes video files then set `frameStart` and
@@ -176,6 +181,8 @@ class CollectVideoData(pyblish.api.InstancePlugin):
     order = pyblish.api.CollectorOrder + 0.4905
     label = "Collect Original Video Frame Data"
     families = ["collect.video.framerange"]
+    hosts = ["traypublisher"]
+    optional = True
 
     def process(self, instance):
         if all(

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -118,7 +118,6 @@ class CollectTraypublisherVideoFrameData(
     hosts = ["traypublisher"]
     optional = True
     settings_category = "traypublisher"
-    default_collect_video_framerange = True
     
     @classmethod
     def get_attr_defs_for_instance(

--- a/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_video_frame_data.py
@@ -119,6 +119,7 @@ class CollectTraypublisherVideoFrameData(
     optional = True
     settings_category = "traypublisher"
     default_collect_video_framerange = True
+    
     @classmethod
     def get_attr_defs_for_instance(
         cls, create_context: "CreateContext", instance: "CreatedInstance"  # noqa: F821

--- a/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -63,6 +63,7 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
             self.log.info("No representations, skipping.")
             return
 
+        frames = None # ensuring `frames` is declared for the final debug which references it
         for repre in repres:
             ext = repre['ext'].replace(".", '')
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -57,9 +57,10 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    default_collect_video_framerange: bool = SettingsField(
-        True,
-        title="Default Collect Original Video Frame Data",
+    CollectTraypublisherVideoFrameData: ValidatePluginModel = SettingsField(
+        default_factory=ValidatePluginModel,
+        title="Collect Original Video Frame Data",
+    )
     CollectCSVIngestPrevalidationReport: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect CSV Ingest Prevalidation Report",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -57,7 +57,7 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectTraypublisherVideoFrameData: ValidatePluginModel = SettingsField(
+    CollectVideoData: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect Original Video Frame Data",
     )
@@ -87,7 +87,7 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
-    "CollectTraypublisherVideoFrameData": {
+    "CollectVideoData": {
         "enabled": True,
         "optional": False,
         "active": True

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -87,7 +87,9 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
-    "default_collect_video_framerange": True,
+    "CollectTraypublisherVideoFrameData": {
+        "default_collect_video_framerange": True,
+    },
     "CollectCSVIngestPrevalidationReport": {
         "enabled": True,
         "optional": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -57,6 +57,10 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
+    default_collect_video_framerange: bool = SettingsField(
+        True,
+        title="Default Collect Original Video Frame Data",
+    )
     CollectSequenceFrameData: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect Original Sequence Frame Data",
@@ -79,6 +83,7 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
+    "default_collect_video_framerange": True,
     "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -57,7 +57,7 @@ class ExtractEditorialPckgConversionModel(BaseSettingsModel):
 
 
 class TrayPublisherPublishPlugins(BaseSettingsModel):
-    CollectVideoData: ValidatePluginModel = SettingsField(
+    CollectTraypublisherVideoFrameData: ValidatePluginModel = SettingsField(
         default_factory=ValidatePluginModel,
         title="Collect Original Video Frame Data",
     )
@@ -87,7 +87,7 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 
 DEFAULT_PUBLISH_PLUGINS = {
-    "CollectVideoData": {
+    "CollectTraypublisherVideoFrameData": {
         "enabled": True,
         "optional": False,
         "active": True

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -88,7 +88,9 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
 
 DEFAULT_PUBLISH_PLUGINS = {
     "CollectTraypublisherVideoFrameData": {
-        "default_collect_video_framerange": True,
+        "enabled": True,
+        "optional": False,
+        "active": True
     },
     "CollectCSVIngestPrevalidationReport": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
Added default_collect_video_framerange setting to control the default of collecting frame range from metadata.

I never want this on when ingesting plates, as the timecode always starts 0, whereas I need the published plates to start according to the frame range already set in AYON.