### PR TITLE
CSV ingest prevalidation: distinguish existing vs higher versions (#YN-0930)

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -163,7 +163,7 @@ class CollectCSVIngestPrevalidationReport(
             int(version) == int(latest_version)
         ):
             return (
-                "Existing version found for the context: "
+                f"Version '{version}' already exists for context: "
                 f"{instance_context_data}"
             )
 
@@ -172,8 +172,9 @@ class CollectCSVIngestPrevalidationReport(
             int(version) < int(latest_version)
         ):
             return (
-                "Higher than current version found for the context: "
-                f"{instance_context_data}"
+                f"Higher version '{latest_version}' already exists disallowing"
+                f" version '{version}' for context:"
+                f" {instance_context_data}"
             )
 
         return ""

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -159,11 +159,20 @@ class CollectCSVIngestPrevalidationReport(
         if version is None:
             return ""
         if (
-            latest_version is not None
-            and int(version) <= int(latest_version)
+            latest_version is not None and
+            int(version) == int(latest_version)
         ):
             return (
-                "Existing version found for context: "
+                "Existing version found for the context: "
+                f"{instance_context_data}"
+            )
+
+        if (
+            latest_version is not None and
+            int(version) < int(latest_version)
+        ):
+            return (
+                "Higher then current version found for the context: "
                 f"{instance_context_data}"
             )
 

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_prevalidation_report.py
@@ -172,7 +172,7 @@ class CollectCSVIngestPrevalidationReport(
             int(version) < int(latest_version)
         ):
             return (
-                "Higher then current version found for the context: "
+                "Higher than current version found for the context: "
                 f"{instance_context_data}"
             )
 


### PR DESCRIPTION
## Changelog Description

Improves CSV ingest prevalidation report messaging to distinguish between existing versions (matching current context) and higher than current versions, providing clearer feedback when a version conflict is detected.

## Additional info

Refactored `_existing_version_check()` in `collect_csv_ingest_prevalidation_report.py` so that the existing-version case returns a specific "Existing" message with instance context data, while the higher-than-current case now has its own dedicated branch returning "Higher than current" with the same context. Previously both conditions returned the same generic message regardless of version relationship.

## Testing notes:

1. Start with an ingest report containing existing (matching) versions — verify message shows existing version found for instance
2. Follow with a case where higher versions exist — verify the distinct "Higher than current" message is displayed

## Dependency
Close [#179](https://github.com/ynput/ayon-traypublisher/issues/179)

## Related support tickets
[YN-0930](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=32080c21d6e7491db9deea3cdd6a2e12)
