### PR TITLE
Chore: Use new editorial families

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_clip_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_clip_instances.py
@@ -37,6 +37,8 @@ class CollectClipInstance(pyblish.api.InstancePlugin):
             return
 
         instance.data["families"].append("clip")
+        # Mark instance for 'ExtractOTIOClipRanges'
+        instance.data["families"].append("otio.clip.ranges")
 
         parent_instance_id = instance.data["parent_instance_id"]
         edit_shared_data = instance.context.data["editorialSharedData"]

--- a/client/ayon_traypublisher/plugins/publish/collect_editorial_workfile.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_editorial_workfile.py
@@ -1,0 +1,18 @@
+import pyblish.api
+
+
+class CollectEditorialWorkfile(pyblish.api.InstancePlugin):
+    """Collect data for instances created by settings creators."""
+
+    label = "Collect Editorial Workfile"
+    order = pyblish.api.CollectorOrder - 0.46
+
+    hosts = ["traypublisher"]
+    families = ["workfile"]
+
+    def process(self, instance):
+        creator_identifier = instance.data["creator_identifier"]
+        if creator_identifier != "editorial_workfile_advanced":
+            return
+        # Mark instance for 'ExtractOTIOFile'
+        instance.data["families"].append("otio.timeline.workfile")

--- a/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_shot_instances.py
@@ -33,6 +33,9 @@ class CollectShotInstance(pyblish.api.InstancePlugin):
     ]
 
     def process(self, instance):
+        # Mark instance for 'ExtractOTIOClipRanges'
+        instance.data["families"].append("otio.clip.ranges")
+
         creator_identifier = instance.data["creator_identifier"]
         if "editorial" not in creator_identifier:
             return


### PR DESCRIPTION
## Changelog Description
Use new families defined in core to process editorial instances.

## Additional review information
[This PR](https://github.com/ynput/ayon-core/pull/1967) in ayon core is adding new families that are used to explicitly process instances instead of host based processing.

As far as I could find workfile instance is not created during simple editorial, if it does we have to add `"otio.timeline.workfile"` to the instance families.

This PR is adding the families but should still work with old core. The same the core PR should work with hiero develop.

## Testing notes:
All possible combinations of ayon-core and ayon-hiero should produce exactly same output.
- traypublisher develop + core develop
- traypublisher PR + core PR
- traypublisher PR + core develop
- traypublisher develop + core PR
