### PR TITLE
Familiy settings

### DIFF
--- a/client/ayon_traypublisher/plugins/publish/collect_explicit_colorspace.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_explicit_colorspace.py
@@ -15,7 +15,6 @@ class CollectColorspace(
     label = "Choose representation colorspace"
     order = pyblish.api.CollectorOrder + 0.49
     hosts = ["traypublisher"]
-    families = ["render", "plate", "reference", "image", "online"]
     enabled = False
 
     default_colorspace_items = [

--- a/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
@@ -10,13 +10,6 @@ class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin):
 
     order = pyblish.api.CollectorOrder + 0.491
     label = "Collect Missing Frame Data From Folder/Task"
-    families = [
-        "plate",
-        "pointcache",
-        "vdbcache",
-        "online",
-        "render",
-    ]
     hosts = ["traypublisher"]
 
     def process(self, instance):

--- a/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_sequence_frame_data.py
@@ -8,7 +8,7 @@ class CollectSequenceFrameData(
     pyblish.api.InstancePlugin,
     OptionalPyblishPluginMixin
 ):
-    """Collect Original Sequence Frame Data
+    """Collect Original Sequence Frame Data.
 
     If the representation includes files with frame numbers,
     then set `frameStart` and `frameEnd` for the instance to the
@@ -17,9 +17,6 @@ class CollectSequenceFrameData(
 
     order = pyblish.api.CollectorOrder + 0.4905
     label = "Collect Original Sequence Frame Data"
-    families = ["plate", "pointcache",
-                "vdbcache", "online",
-                "render"]
     hosts = ["traypublisher"]
     optional = True
 

--- a/client/ayon_traypublisher/plugins/publish/validate_colorspace.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_colorspace.py
@@ -18,7 +18,6 @@ class ValidateColorspace(pyblish.api.InstancePlugin,
     label = "Validate representation colorspace"
     order = pyblish.api.ValidatorOrder
     hosts = ["traypublisher"]
-    families = ["render", "plate", "reference", "image", "online"]
 
     def process(self, instance):
 

--- a/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_frame_ranges.py
@@ -15,7 +15,6 @@ class ValidateFrameRange(OptionalPyblishPluginMixin,
 
     label = "Validate Frame Range"
     hosts = ["traypublisher"]
-    families = ["render", "plate"]
     targets = ["local"]
 
     order = ValidateContentsOrder

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -74,6 +74,13 @@ def _convert_families_0_5_0(overrides: dict):
             "image",
             "online",
         ],
+        "CollectFrameDataFromAssetEntity": [
+            "plate",
+            "pointcache",
+            "vdbcache",
+            "online",
+            "render",
+        ],
         "CollectSequenceFrameData": [
             "plate",
             "pointcache",

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -88,6 +88,13 @@ def _convert_families_0_5_0(overrides: dict):
             "online",
             "render",
         ],
+        "ValidateColorspace": [
+            "render",
+            "plate",
+            "reference",
+            "image",
+            "online",
+        ],
         "ValidateFrameRange": [
             "render",
             "plate",

--- a/server/settings/conversion.py
+++ b/server/settings/conversion.py
@@ -57,6 +57,43 @@ def _convert_editorial_0_4_0(overrides):
         editorial_simple["product_base_type_presets"] = presets
 
 
+def _convert_families_0_5_0(overrides: dict):
+    """Convert families settings for plugins.
+
+    v0.5 added settings for control the families of plugins.
+    This conversion fills in the previously hardcoded families to preserve
+    the previous behavior.
+
+    """
+    # old values, pre 0.5.0
+    old_families = {
+        "CollectColorspace": [
+            "render",
+            "plate",
+            "reference",
+            "image",
+            "online",
+        ],
+        "CollectSequenceFrameData": [
+            "plate",
+            "pointcache",
+            "vdbcache",
+            "online",
+            "render",
+        ],
+        "ValidateFrameRange": [
+            "render",
+            "plate",
+        ],
+    }
+
+    publish_settings = overrides.setdefault("publish", {})
+
+    for plugin_name, families in old_families.items():
+        plugin_settings = publish_settings.setdefault(plugin_name, {})
+        plugin_settings.setdefault("families", []).extend(families)
+
+
 def convert_settings_overrides(
     source_version: str,
     overrides: dict[str, Any],
@@ -64,4 +101,5 @@ def convert_settings_overrides(
     _convert_csv_ingest_0_3_9(overrides)
     _convert_simple_creators_0_4_0(overrides)
     _convert_editorial_0_4_0(overrides)
+    _convert_families_0_5_0(overrides)
     return overrides

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,12 +11,15 @@ class ValidatePluginModel(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
-class ValidateFamiliesModel(ValidatePluginModel):
-
+class FamiliesModel(BaseSettingsModel):
     families: list[str] = SettingsField(
         title="Families",
         default=["*"],
     )
+
+
+class ValidateFamiliesModel(ValidatePluginModel, FamiliesModel):
+    pass
 
 
 class ValidateFrameRangeModel(ValidateFamiliesModel):
@@ -72,6 +75,10 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
     CollectColorspace: ValidateFamiliesModel = SettingsField(
         default_factory=ValidateFamiliesModel,
         title="Collect Colorspace",
+    )
+    CollectFrameDataFromAssetEntity: FamiliesModel = SettingsField(
+        default_factory=FamiliesModel,
+        title="Collect Missing Frame Data From Folder/Task",
     )
     CollectSequenceFrameData: ValidateFamiliesModel = SettingsField(
         default_factory=ValidateFamiliesModel,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -11,7 +11,13 @@ class ValidatePluginModel(BaseSettingsModel):
     active: bool = SettingsField(True, title="Active")
 
 
-class ValidateFrameRangeModel(ValidatePluginModel):
+class ValidateFamiliesModel(ValidatePluginModel):
+
+    families: list[str] = SettingsField(
+        title="Families",
+        default=["*"],
+    )
+
     """Allows to publish multiple video files in one go. <br />Name of matching
      asset is parsed from file names ('asset.mov', 'asset_v001.mov',
      'my_asset_to_publish.mov')"""

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -88,6 +88,10 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
         title="Validate Frame Range",
         default_factory=ValidateFrameRangeModel,
     )
+    ValidateColorspace: FamiliesModel = SettingsField(
+        default_factory=FamiliesModel,
+        title="Validate Colorspace",
+    )
     ValidateExistingVersion: ValidatePluginModel = SettingsField(
         title="Validate Existing Version",
         default_factory=ValidatePluginModel,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -67,8 +67,8 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
         default_factory=ValidatePluginModel,
         title="Collect CSV Ingest Prevalidation Report",
     )
-    CollectSequenceFrameData: ValidatePluginModel = SettingsField(
-        default_factory=ValidatePluginModel,
+    CollectSequenceFrameData: ValidateFamiliesModel = SettingsField(
+        default_factory=ValidateFamiliesModel,
         title="Collect Original Sequence Frame Data",
     )
     ValidateFrameRange: ValidateFrameRangeModel = SettingsField(
@@ -97,7 +97,8 @@ DEFAULT_PUBLISH_PLUGINS = {
     "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,
-        "active": True
+        "active": True,
+        "families": ["*"],
     },
     "ValidateFrameRange": {
         "enabled": True,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -96,7 +96,6 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
         title="Validate Existing Version",
         default_factory=ValidatePluginModel,
     )
-
     ExtractEditorialPckgConversion: ExtractEditorialPckgConversionModel = (
         SettingsField(
             default_factory=ExtractEditorialPckgConversionModel,
@@ -117,6 +116,9 @@ DEFAULT_PUBLISH_PLUGINS = {
         "active": True,
         "families": ["*"],
     },
+    "CollectFrameDataFromAssetEntity": {
+        "families": ["*"],
+    },
     "CollectSequenceFrameData": {
         "enabled": True,
         "optional": True,
@@ -127,6 +129,9 @@ DEFAULT_PUBLISH_PLUGINS = {
         "enabled": True,
         "optional": True,
         "active": True,
+        "families": ["*"],
+    },
+    "ValidateColorspace": {
         "families": ["*"],
     },
     "ValidateExistingVersion": {

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -18,6 +18,8 @@ class ValidateFamiliesModel(ValidatePluginModel):
         default=["*"],
     )
 
+
+class ValidateFrameRangeModel(ValidateFamiliesModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
      asset is parsed from file names ('asset.mov', 'asset_v001.mov',
      'my_asset_to_publish.mov')"""
@@ -96,7 +98,7 @@ DEFAULT_PUBLISH_PLUGINS = {
     "CollectCSVIngestPrevalidationReport": {
         "enabled": True,
         "optional": True,
-        "active": True
+        "active": True,
     },
     "CollectColorspace": {
         "enabled": True,
@@ -113,12 +115,13 @@ DEFAULT_PUBLISH_PLUGINS = {
     "ValidateFrameRange": {
         "enabled": True,
         "optional": True,
-        "active": True
+        "active": True,
+        "families": ["*"],
     },
     "ValidateExistingVersion": {
         "enabled": True,
         "optional": True,
-        "active": True
+        "active": True,
     },
     "ExtractEditorialPckgConversion": {
         "conversion_enabled": False,
@@ -128,14 +131,14 @@ DEFAULT_PUBLISH_PLUGINS = {
               "video_filters": [],
               "audio_filters": [],
               "input": [
-                "-apply_trc gamma22"
+                "-apply_trc gamma22",
               ],
               "output": [
                 "-pix_fmt yuv420p",
                 "-crf 18",
                 "-g 1",
-              ]
-            }
-        }
-    }
+              ],
+            },
+        },
+    },
 }

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -67,6 +67,10 @@ class TrayPublisherPublishPlugins(BaseSettingsModel):
         default_factory=ValidatePluginModel,
         title="Collect CSV Ingest Prevalidation Report",
     )
+    CollectColorspace: ValidateFamiliesModel = SettingsField(
+        default_factory=ValidateFamiliesModel,
+        title="Collect Colorspace",
+    )
     CollectSequenceFrameData: ValidateFamiliesModel = SettingsField(
         default_factory=ValidateFamiliesModel,
         title="Collect Original Sequence Frame Data",
@@ -93,6 +97,12 @@ DEFAULT_PUBLISH_PLUGINS = {
         "enabled": True,
         "optional": True,
         "active": True
+    },
+    "CollectColorspace": {
+        "enabled": True,
+        "optional": True,
+        "active": True,
+        "families": ["*"],
     },
     "CollectSequenceFrameData": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description
adds a `familiy` setting to various tray_publisher settings.

## Additional review information

this came up when trying to publish `prerender` products via the trayPublisher.

<img  height="400" alt="image" src="https://github.com/user-attachments/assets/d474e52f-d134-4be2-aee2-a9f5791e1570" />


`_convert_families_0_5_0` should make sure that when users upgrade the same famlies get set, which used to be hardcoded before, resulting in no change in behaviour
<img height="400" alt="image" src="https://github.com/user-attachments/assets/8c6a7cea-dc53-4724-8767-522ae18449a3" />


## Testing notes:
1. add a new `product_type` to one or more of the plugin settings
2. publish a product of that type
3. confirm the plugin ran as expected

4. remove a prduct type from one of the plugin settings
5. publish a product of that type
6. confirm the plugin did not run



