### PR TITLE
Create CSV: Missing required columns show actual missing columns in message

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -887,8 +887,8 @@ configuration in project settings.
         csv_reader.fieldnames = list(all_columns)
 
         # check if csv file contains all required columns
-        if any(column not in all_columns for column in required_columns):
-            missing = sorted(set(required_columns) - set(all_columns))
+    missing = sorted(set(required_columns) - set(all_columns))
+    if missing:
             all_columns: list[str] = sorted(all_columns)
             required_columns = sorted(required_columns)
 

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -881,20 +881,20 @@ configuration in project settings.
         )
 
         # Fix fieldnames – strip accidental leading/trailing whitespace.
-        all_columns: set[str] = {
+        csv_columns: set[str] = {
             column.strip() for column in csv_reader.fieldnames
         }
-        csv_reader.fieldnames = list(all_columns)
+        csv_reader.fieldnames = list(csv_columns)
 
         # check if csv file contains all required columns
-    missing = sorted(set(required_columns) - set(all_columns))
-    if missing:
-            all_columns: list[str] = sorted(all_columns)
+        missing = sorted(set(required_columns) - set(csv_columns))
+        if missing:
+            csv_columns: list[str] = sorted(csv_columns)
             required_columns = sorted(required_columns)
 
             raise CreatorError(
                 f"Missing required columns: {missing}\n\n"
-                f"Columns in CSV file: {all_columns}\n"
+                f"Columns in CSV file: {csv_columns}\n"
                 f"All required columns: {required_columns}"
             )
 
@@ -962,7 +962,7 @@ configuration in project settings.
                     "Provide the values in the CSV or ensure the matched "
                     "folder has these attributes set."
                 )
-                if prevalidation["missing_frame_range_values"]["mode"] == "ignore":  # noqa
+                if prevalidation["missing_frame_range_values"]["mode"] == "ignore":  # noqa: E501
                     report_data.setdefault(
                         "Missing Frame Range Values", []
                     ).append(error_msg)

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -881,13 +881,13 @@ configuration in project settings.
         )
 
         # Fix fieldnames – strip accidental leading/trailing whitespace.
-        csv_columns: set[str] = {
+        csv_reader.fieldnames = [
             column.strip() for column in csv_reader.fieldnames
-        }
-        csv_reader.fieldnames = list(csv_columns)
+        ]
+        csv_columns: set[str] = set(csv_reader.fieldnames)
 
         # check if csv file contains all required columns
-        missing = sorted(set(required_columns) - set(csv_columns))
+        missing = sorted(set(required_columns) - csv_columns)
         if missing:
             csv_columns: list[str] = sorted(csv_columns)
             required_columns = sorted(required_columns)

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -895,7 +895,7 @@ configuration in project settings.
             raise CreatorError(
                 f"Missing required columns: {missing}\n\n"
                 f"Columns in CSV file: {all_columns}\n"
-                f"Required columns: {required_columns}"
+                f"All required columns: {required_columns}"
             )
 
         # Read all rows upfront so we can make targeted API calls before

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -881,17 +881,21 @@ configuration in project settings.
         )
 
         # Fix fieldnames – strip accidental leading/trailing whitespace.
-        all_columns = [
-            " ".join(column.rsplit())
-            for column in csv_reader.fieldnames
-        ]
-        csv_reader.fieldnames = all_columns
+        all_columns: set[str] = {
+            column.strip() for column in csv_reader.fieldnames
+        }
+        csv_reader.fieldnames = list(all_columns)
 
         # check if csv file contains all required columns
         if any(column not in all_columns for column in required_columns):
+            missing = sorted(set(required_columns) - set(all_columns))
+            all_columns: list[str] = sorted(all_columns)
+            required_columns = sorted(required_columns)
+
             raise CreatorError(
-                f"Missing required columns: {required_columns}\n"
-                f"All columns: {all_columns}"
+                f"Missing required columns: {missing}\n\n"
+                f"Columns in CSV file: {all_columns}\n"
+                f"Required columns: {required_columns}"
             )
 
         # Read all rows upfront so we can make targeted API calls before


### PR DESCRIPTION
## Changelog Description

Report only the 'missing' required columns first so it's easy to see which ones actually did not get a match. Then still display what it's in the CSV file and all required columns just for clarity to the user.

## Additional review information

Instead of only listing all required columns, now it will list first only those that are actually missing - so it's directly clear that "these ones are missing." instead of also listing the 10s of columns it did match fine.

## Testing notes:

1. Create CSV should report better message on not having a required column on create.
