### PR TITLE
fix: keep folder/task settable on editorial shots (YN-0813)

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_advanced.py
@@ -137,6 +137,11 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
     def collect_instances(self):
         super().collect_instances()
+        # Only clip instances have a "promised" context (resolved from the
+        # parent shot during publish). Shots keep an editable context so
+        # users can set the destination folder/task. See YN-0813.
+        if self.product_base_type == "shot":
+            return
         for instance in self.create_context.instances:
             if instance.creator_identifier == self.identifier:
                 instance.transient_data["has_promised_context"] = True
@@ -1006,7 +1011,6 @@ or updating already created. Publishing will create OTIO file.
         c_instance = self.create_context.creators["editorial_shot_advanced"].create(
             instance_data
         )
-        c_instance.transient_data["has_promised_context"] = True
         parenting_data.update(
             {
                 "instance_label": label,

--- a/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
+++ b/client/ayon_traypublisher/plugins/create/create_editorial_simple.py
@@ -126,6 +126,11 @@ class EditorialClipInstanceCreatorBase(HiddenTrayPublishCreator):
 
     def collect_instances(self):
         super().collect_instances()
+        # Only clip instances have a "promised" context (resolved from the
+        # parent shot during publish). Shots keep an editable context so
+        # users can set the destination folder/task. See YN-0813.
+        if self.product_base_type == "shot":
+            return
         for instance in self.create_context.instances:
             if instance.creator_identifier == self.identifier:
                 instance.transient_data["has_promised_context"] = True
@@ -624,7 +629,6 @@ or updating already created. Publishing will create OTIO file.
                 "instance_label": label,
                 "instance_id": c_instance.data["instance_id"]
             })
-            c_instance.transient_data["has_promised_context"] = True
         else:
             # add review family if defined
             instance_data.update({


### PR DESCRIPTION
## Summary

Fixes **#184 (YN-0813)**: the folder/task selector on shots created by the **Editorial Simple** creator is greyed out, and publish fails when the anatomy template uses the `{task}` key.

## Root cause

Commit `01a2e51d` (*"Add 'has_promised_context' to clip instances"*, shipped in the 0.4.x release window mentioned in the issue) set `has_promised_context = True` on **shot** instances too — not only on clip instances as its title states.

In ayon-core's `product_context.py`, that flag sets `context_editable = False`, which disables the folder/task editor on the instance. With the editor disabled the user can't pick a destination task, so templates containing `{task}` fail in Integrate Asset because the task never exists.

## The fix

Only clip instances (whose context is resolved from the parent shot at publish time) keep `has_promised_context = True`. Shot instances remain editable so the user can set the destination folder/task again:

- `create_editorial_simple.py`:
  - `collect_instances()` now returns early when `product_base_type == "shot"`.
  - The shot branch of `_make_shot_product_instance` no longer sets the flag.
- `create_editorial_advanced.py`: same guard + flag removal on `editorial_shot_advanced` (same regression, same commit).

## Validation

- `python -m py_compile` passes on both files.
- Logic test (9/9) simulating `collect_instances` with mocks: shots no longer receive the flag, clips still do.
- Clip instances keep their promised context — their context comes from the parent shot, unchanged behavior.

Closes #184