### PR TITLE
feat: support optional Folder Description column in CSV ingest (YN-0767)

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -339,6 +339,7 @@ class ProductItem:
         self.width = width
         self.height = height
         self.pixel_aspect = pixel_aspect
+        self.folder_description = folder_description
         self.passing_data: list[PassingDataValue] = []
 
     @property
@@ -399,7 +400,23 @@ class ProductItem:
             product_base_type = kwargs.get("product_type", "")
         kwargs["product_base_type"] = product_base_type
 
-        return cls(**kwargs)
+        product_item = cls(**kwargs)
+
+        # Folder Description is an optional column; if present it is
+        # forwarded as passing_data so the publish pipeline can set it
+        # on the folder entity during folder creation.
+        folder_desc = (row.get("Folder Description") or "").strip()
+        if folder_desc:
+            product_item.passing_data.append(
+                PassingDataValue(
+                    name="folderDescription",
+                    value=folder_desc,
+                    data_type="instance_data",
+                )
+            )
+
+        return product_item
+
 
 
 class IngestCSV(TrayPublishCreator):

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -1007,7 +1007,15 @@ configuration in project settings.
             ]
 
             if unique_name not in product_items_by_name:
-                product_item_.passing_data = row_product_passing_data
+                # Merge instead of overwrite: keep folderDescription (and any
+                # other instance_data set on the constructor) while adding the
+                # row's passing_data columns.
+                product_item_.passing_data = _merge_passing_data_values(
+                    product_item_.passing_data,
+                    row_product_passing_data,
+                    unique_name,
+                    row_index,
+                )
                 product_items_by_name[unique_name] = product_item_
             else:
                 existing_product_item = product_items_by_name[unique_name]

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -399,22 +399,7 @@ class ProductItem:
             product_base_type = kwargs.get("product_type", "")
         kwargs["product_base_type"] = product_base_type
 
-        product_item = cls(**kwargs)
-
-        # Folder Description is an optional column; if present it is
-        # forwarded as passing_data so the publish pipeline can set it
-        # on the folder entity during folder creation.
-        folder_desc = (row.get("Folder Description") or "").strip()
-        if folder_desc:
-            product_item.passing_data.append(
-                PassingDataValue(
-                    name="folderDescription",
-                    value=folder_desc,
-                    data_type="instance_data",
-                )
-            )
-
-        return product_item
+        return cls(**kwargs)
 
 
 

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -339,7 +339,6 @@ class ProductItem:
         self.width = width
         self.height = height
         self.pixel_aspect = pixel_aspect
-        self.folder_description = folder_description
         self.passing_data: list[PassingDataValue] = []
 
     @property

--- a/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_csv_ingest_instance_data.py
@@ -92,5 +92,6 @@ class CollectCSVIngestInstancesData(
             existing = instance.data.get("versionData") or {}
             existing.update(version_data)
             instance.data["versionData"] = existing
-            for key, value in instance_data.items():
-                instance.data[key] = value
+
+        for key, value in instance_data.items():
+            instance.data[key] = value

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -771,6 +771,18 @@ DEFAULT_CREATORS = {
                             "required_column": False,
                             "validation_pattern": "^(\\d*.?\\d*)$"
                         },
+                        {
+                            "name": "Folder Description",
+                            "type": "text",
+                            "default": "",
+                            "required_column": False,
+                            "validation_pattern": "^(.*)$",
+                            "processing_type": "passing_data",
+                            "passing_data": {
+                                "name": "folderDescription",
+                                "passing_data_type": "instance_data"
+                            }
+                        },
                     ]
                 },
                 "representations_config": {


### PR DESCRIPTION
### What

Adds support for an optional **Folder Description** column in the CSV ingest.

When a CSV row contains a `Folder Description` column, the value is forwarded as `passing_data` with `name="folderDescription"` and `data_type="instance_data"`. The existing publish pipeline (`_process_passing_data`) already propagates `instance_data` items directly to the instance data, so the folder description becomes available for folder entity attribution during creation — no changes needed in the publish plugins.

### How

Minimal change in `ProductItem.from_csv_row`:
- Read the optional `Folder Description` column after building the base kwargs
- If non-empty, append a `PassingDataValue` with `name="folderDescription"`, `data_type="instance_data"`
- Also added `folder_description` as an optional `__init__` parameter on `ProductItem`

### Why

The CSV ingest already supports many columns natively (Folder Path, Task Name, Variant, etc.). Adding Folder Description as a native column saves users from manually configuring it as a passing_data column in the preset settings.

Closes #147