### PR TITLE
Make ValidateExistingVersion repair work for all publish types

### DIFF
--- a/client/ayon_traypublisher/api/plugin.py
+++ b/client/ayon_traypublisher/api/plugin.py
@@ -63,6 +63,14 @@ class HiddenTrayPublishCreator(HiddenCreator):
         self._add_instance_to_context(new_instance)
 
 
+    def repair_version_conflict(self, created_instance, publish_instance):
+        """Repair an instance whose version was explicitly overridden."""
+        latest_version = publish_instance.data["latestVersion"]
+        next_version = int(latest_version) + 1
+        created_instance["version"] = next_version
+        publish_instance.data["version"] = next_version
+
+
 class TrayPublishCreator(Creator):
     create_allow_context_change = True
     host_name = "traypublisher"
@@ -102,6 +110,13 @@ class TrayPublishCreator(Creator):
 
         # Add instance to current context
         self._add_instance_to_context(new_instance)
+
+    def repair_version_conflict(self, created_instance, publish_instance):
+        """Repair an instance whose version was explicitly overridden."""
+        latest_version = publish_instance.data["latestVersion"]
+        next_version = int(latest_version) + 1
+        created_instance["version"] = next_version
+        publish_instance.data["version"] = next_version
 
 
 class SettingsCreator(TrayPublishCreator):
@@ -156,6 +171,14 @@ class SettingsCreator(TrayPublishCreator):
 
         if thumbnail_path:
             self.set_instance_thumbnail_path(new_instance.id, thumbnail_path)
+
+    def repair_version_conflict(self, created_instance, publish_instance):
+        creator_attributes = created_instance["creator_attributes"]
+        if "use_next_version" in creator_attributes:
+            creator_attributes["use_next_version"] = True
+            return
+
+        super().repair_version_conflict(created_instance, publish_instance)
 
     def _prepare_next_versions(self, folder_paths, product_names):
         """Prepare next versions for given folder and product names.

--- a/client/ayon_traypublisher/api/plugin.py
+++ b/client/ayon_traypublisher/api/plugin.py
@@ -62,7 +62,6 @@ class HiddenTrayPublishCreator(HiddenCreator):
         # Add instance to current context
         self._add_instance_to_context(new_instance)
 
-
     def repair_version_conflict(self, created_instance, publish_instance):
         """Repair an instance whose version was explicitly overridden."""
         latest_version = publish_instance.data["latestVersion"]

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -444,6 +444,10 @@ configuration in project settings.
             if instance.product_base_type == "csv_ingest_file":
                 instance.set_mandatory(True)
 
+    def repair_version_conflict(self, created_instance, publish_instance):
+        """Repair the explicit version read from CSV data."""
+        super().repair_version_conflict(created_instance, publish_instance)
+
     def get_pre_create_attr_defs(self):
         """Creating pre-create attributes at creator plugin.
 

--- a/client/ayon_traypublisher/plugins/create/create_movie_batch.py
+++ b/client/ayon_traypublisher/plugins/create/create_movie_batch.py
@@ -162,6 +162,10 @@ class BatchMovieCreator(TrayPublishCreator):
 
         return product_name
 
+    def repair_version_conflict(self, created_instance, publish_instance):
+        """Repair the version parsed from the movie filename."""
+        super().repair_version_conflict(created_instance, publish_instance)
+
     def get_instance_attr_defs(self):
         return [
             BoolDef(

--- a/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
@@ -54,19 +54,12 @@ class ValidateExistingVersion(
             instance.data["instance_id"]
         )
 
-        creator_attributes = created_instance["creator_attributes"]
-
-        if "use_next_version" in creator_attributes:
-            # Settings creators with version control
-            creator_attributes["use_next_version"] = True
-            create_context.save_changes()
-            return
-
-        # Creators such as Batch Movies store the version directly
-        latest_version = instance.data.get("latestVersion") or 0
-        next_version = latest_version + 1
-
-        created_instance["version"] = next_version
-        instance.data["version"] = next_version
+        # Get the creator responsible for the instance so its version
+        # repair implementation can be used.
+        creators = create_context.get_sorted_creators(
+            [created_instance.creator_identifier]
+        )
+        creator = creators[0]
+        creator.repair_version_conflict(created_instance, instance)
 
         create_context.save_changes()

--- a/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
@@ -56,10 +56,7 @@ class ValidateExistingVersion(
 
         # Get the creator responsible for the instance so its version
         # repair implementation can be used.
-        creators = create_context.get_sorted_creators(
-            [created_instance.creator_identifier]
-        )
-        creator = creators[0]
+        creator = create_context.creators[created_instance.creator_identifier]
         creator.repair_version_conflict(created_instance, instance)
 
         create_context.save_changes()

--- a/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
+++ b/client/ayon_traypublisher/plugins/publish/validate_existing_version.py
@@ -51,8 +51,22 @@ class ValidateExistingVersion(
     def repair(cls, instance):
         create_context = instance.context.data["create_context"]
         created_instance = create_context.get_instance_by_id(
-            instance.data["instance_id"])
+            instance.data["instance_id"]
+        )
+
         creator_attributes = created_instance["creator_attributes"]
-        # Disable version override
-        creator_attributes["use_next_version"] = True
+
+        if "use_next_version" in creator_attributes:
+            # Settings creators with version control
+            creator_attributes["use_next_version"] = True
+            create_context.save_changes()
+            return
+
+        # Creators such as Batch Movies store the version directly
+        latest_version = instance.data.get("latestVersion") or 0
+        next_version = latest_version + 1
+
+        created_instance["version"] = next_version
+        instance.data["version"] = next_version
+
         create_context.save_changes()


### PR DESCRIPTION
## Changelog Description
Updated existing-version repair to delegate version changes to the responsible creator.
This allows creators with different version sources, such as Batch Movies and CSV Ingest, to repair conflicts without assuming that `use_next_version` exists.

## Additional review information
Another simple way of fixing it could be just adding condition in `repair` method:
```
@classmethod
def repair(cls, instance):
    create_context = instance.context.data["create_context"]
    created_instance = create_context.get_instance_by_id(
        instance.data["instance_id"]
    )

    creator_attributes = created_instance["creator_attributes"]

    if "use_next_version" in creator_attributes:
        # Version-controlled Simple Creator
        creator_attributes["use_next_version"] = True
    else:
        # Explicit-version creators such as Batch Movies and CSV Ingest
        latest_version = instance.data["latestVersion"]
        next_version = int(latest_version) + 1

        created_instance["version"] = next_version
        instance.data["version"] = next_version

    create_context.save_changes()
```

But I find the current implementation more future-proof as it lets each creator handle version repairs its own way.

## Testing notes:
1. test publish in with different publish types
2. test  `Batch Movie` publish with file name that is `< or ==` than the latest published one and try `repair`
3. test repair in other publish types (force incorrect version number to be able to use repair)