### PR TITLE
Remove openpype and avalon references

### DIFF
--- a/client/ayon_traypublisher/addon.py
+++ b/client/ayon_traypublisher/addon.py
@@ -108,12 +108,12 @@ class TrayPublishAddon(
             required=True
         ).option(
             "--folder-path",
-            help="Asset name in which the context will be used",
+            help="Folder path in which the context will be used",
             type=str,
             required=True
         ).option(
             "--task",
-            help="Task name under Asset in which the context will be used",
+            help="Task name under Folder in which the context will be used",
             type=str,
             required=False
         ).option(

--- a/client/ayon_traypublisher/batch_parsing.py
+++ b/client/ayon_traypublisher/batch_parsing.py
@@ -1,4 +1,4 @@
-"""Functions to parse asset names, versions from file names"""
+"""Functions to parse folder names and versions from file names."""
 import os
 
 import ayon_api

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -485,7 +485,7 @@ configuration in project settings.
         """Create product from each row found in the CSV.
 
         Args:
-            product_name (str): The subset name.
+            product_name (str): The product name.
             instance_data (dict): The instance data.
             pre_create_data (dict):
         """
@@ -550,7 +550,7 @@ configuration in project settings.
 
         Args:
             preset_data (dict[str, Any]): The selected preset data.
-            product_name (str): The subset name.
+            product_name (str): The product name.
             instance_data (dict): The instance data.
             csv_dir (str): The csv directory.
             filename (str): The filename.

--- a/client/ayon_traypublisher/plugins/create/create_texture.py
+++ b/client/ayon_traypublisher/plugins/create/create_texture.py
@@ -260,9 +260,9 @@ class TextureCreator(TrayPublishCreator):
                 tooltip=(
                     "Remove common prefix from the variant name.\n\n"
                     "This is useful when publishing a batch of textures "
-                    "for an asset that all start with the asset name.\n"
+                    "for files that all start with the product name.\n"
                     "By stripping the common prefix, the variant name will "
-                    "then exclude the asset name."
+                    "then exclude the product name."
                 )
             ),
             BoolDef(

--- a/client/ayon_traypublisher/plugins/create/create_texture.py
+++ b/client/ayon_traypublisher/plugins/create/create_texture.py
@@ -260,7 +260,7 @@ class TextureCreator(TrayPublishCreator):
                 tooltip=(
                     "Remove common prefix from the variant name.\n\n"
                     "This is useful when publishing a batch of textures "
-                    "for files that all start with the product name.\n"
+                    "for an asset that all start with the asset name.\n"
                     "By stripping the common prefix, the variant name will "
                     "then exclude the product name."
                 )

--- a/client/ayon_traypublisher/plugins/create/create_texture.py
+++ b/client/ayon_traypublisher/plugins/create/create_texture.py
@@ -262,7 +262,7 @@ class TextureCreator(TrayPublishCreator):
                     "This is useful when publishing a batch of textures "
                     "for an asset that all start with the asset name.\n"
                     "By stripping the common prefix, the variant name will "
-                    "then exclude the product name."
+                    "then exclude the asset name."
                 )
             ),
             BoolDef(

--- a/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
+++ b/client/ayon_traypublisher/plugins/publish/collect_frame_data_from_folder_entity.py
@@ -1,7 +1,7 @@
 import pyblish.api
 
 
-class CollectFrameDataFromAssetEntity(pyblish.api.InstancePlugin):
+class CollectFrameDataFromFolderEntity(pyblish.api.InstancePlugin):
     """Collect Frame Data From `taskEntity` or `folderEntity` of instance.
 
     Frame range data will only be collected if the keys are not yet

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -26,8 +26,8 @@ class ProductTypeItemModel(BaseSettingsModel):
 
 class BatchMovieCreatorPlugin(BaseSettingsModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
-     asset is parsed from file names ('asset.mov', 'asset_v001.mov',
-     'my_asset_to_publish.mov')"""
+     folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
+     'my_folder_to_publish.mov')"""
 
     default_variants: list[str] = SettingsField(
         title="Default variants",
@@ -85,8 +85,8 @@ def _value_type_enum() -> list[dict[str, str]]:
 
 class ColumnItemModel(BaseSettingsModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
-     asset is parsed from file names ('asset.mov', 'asset_v001.mov',
-     'my_asset_to_publish.mov')"""
+     folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
+     'my_folder_to_publish.mov')"""
 
     _layout = "expanded"
     name: str = SettingsField(
@@ -364,8 +364,8 @@ class ListConfigModel(BaseSettingsModel):
 class RepresentationItemModel(BaseSettingsModel):
     """Allows to publish multiple video files in one go.
 
-    Name of matching asset is parsed from file names
-    ('asset.mov', 'asset_v001.mov', 'my_asset_to_publish.mov')
+    Name of matching folder is parsed from file names
+    ('folder.mov', 'folder_v001.mov', 'my_folder_to_publish.mov')
     """
 
     _layout = "expanded"

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -25,7 +25,7 @@ class ProductTypeItemModel(BaseSettingsModel):
 
 
 class BatchMovieCreatorPlugin(BaseSettingsModel):
-    """Allows to publish multiple video files in one go. <br />Name of matching
+    """Allows to publish multiple video files in one go. Name of matching
      folder is parsed from file names ('folder.mov', 'folder_v001.mov',
      'my_folder_to_publish.mov')"""
 
@@ -84,7 +84,7 @@ def _value_type_enum() -> list[dict[str, str]]:
 
 
 class ColumnItemModel(BaseSettingsModel):
-    """Allows to publish multiple video files in one go. <br />Name of matching
+    """Allows to publish multiple video files in one go. Name of matching
      folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
      'my_folder_to_publish.mov')"""
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -26,7 +26,7 @@ class ProductTypeItemModel(BaseSettingsModel):
 
 class BatchMovieCreatorPlugin(BaseSettingsModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
-     folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
+     folder is parsed from file names ('folder.mov', 'folder_v001.mov',
      'my_folder_to_publish.mov')"""
 
     default_variants: list[str] = SettingsField(

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -13,7 +13,7 @@ class ValidatePluginModel(BaseSettingsModel):
 
 class ValidateFrameRangeModel(ValidatePluginModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
-     folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
+     folder is parsed from file names ('folder.mov', 'folder_v001.mov',
      'my_folder_to_publish.mov')"""
 
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -12,7 +12,7 @@ class ValidatePluginModel(BaseSettingsModel):
 
 
 class ValidateFrameRangeModel(ValidatePluginModel):
-    """Allows to publish multiple video files in one go. <br />Name of matching
+    """Allows to publish multiple video files in one go. Name of matching
      folder is parsed from file names ('folder.mov', 'folder_v001.mov',
      'my_folder_to_publish.mov')"""
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -13,8 +13,8 @@ class ValidatePluginModel(BaseSettingsModel):
 
 class ValidateFrameRangeModel(ValidatePluginModel):
     """Allows to publish multiple video files in one go. <br />Name of matching
-     asset is parsed from file names ('asset.mov', 'asset_v001.mov',
-     'my_asset_to_publish.mov')"""
+     folder name is parsed from file names ('folder.mov', 'folder_v001.mov',
+     'my_folder_to_publish.mov')"""
 
 
 class ExtractEditorialPckgFFmpegModel(BaseSettingsModel):


### PR DESCRIPTION
## Changelog Description
Removing OpenPype and Avalon references mostly in docstrings. The functionality shouldn't be affected - no "real" code was changed.

## Testing notes:
Probably not needed.
