### PR TITLE
[YN-1035]: Use CSV passing-data defaults

### DIFF
--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -120,7 +120,7 @@ def _collect_passing_data_columns(
         result.append(
             PassingDataValue(
                 name=passing_data_cfg["name"],
-                value=value or column.get("default"),
+                value=value if value is not None else column.get("default"),
                 data_type=passing_data_cfg["passing_data_type"],
             )
         )

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -45,8 +45,11 @@ def _get_row_value_with_validation(
             f"Column '{column_name}' not found in column config."
         )
 
-    # get column value from row
-    column_value = row_data.get(column_name)
+    # get column value from row and if it does not exist, use default value
+    column_value = (
+        row_data.get(column_name)
+        if row_data.get(column_name) is not None else column_data["default"]
+    )
     column_required = column_data["required_column"]
 
     # check if column value is not empty string and column is required
@@ -120,7 +123,7 @@ def _collect_passing_data_columns(
         result.append(
             PassingDataValue(
                 name=passing_data_cfg["name"],
-                value=value if value is not None else column.get("default"),
+                value=value,
                 data_type=passing_data_cfg["passing_data_type"],
             )
         )

--- a/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
+++ b/client/ayon_traypublisher/plugins/create/create_csv_ingest.py
@@ -120,7 +120,7 @@ def _collect_passing_data_columns(
         result.append(
             PassingDataValue(
                 name=passing_data_cfg["name"],
-                value=value,
+                value=value or column.get("default"),
                 data_type=passing_data_cfg["passing_data_type"],
             )
         )


### PR DESCRIPTION
## Changelog Description
CSV ingest now uses the configured column default when a passing-data value is not provided. This keeps imported entities populated with the intended default values.

## Additional info
The fallback is applied while collecting passing-data columns, before values are stored in the resulting passing-data payload.

## Testing notes:
1. Create new custom attribute in version scope
<img width="632" height="521" alt="image" src="https://github.com/user-attachments/assets/c3ac73ab-512d-431c-9b8c-498dfd47e2b8" />

2. Configure a CSV passing-data column with a default value `ayon+settings://traypublisher/create/IngestCSV/presets/0/columns_config/columns`.
<img width="692" height="340" alt="image" src="https://github.com/user-attachments/assets/bdccb75f-40fd-41ed-a3a5-540d33afcc7a" />


3. Ingest a CSV row without a value for that column.

4. Verify the resulting passing-data value uses the configured default.
<img width="467" height="626" alt="image" src="https://github.com/user-attachments/assets/a5d906b3-52dc-4944-bb34-a2cfce77d241" />


## Dependency
Close https://github.com/ynput/ayon-traypublisher/issues/191

## Related support tickets
[YN-1035](https://support.ayon.app/projects/Active_Clients/overview?project=Active_Clients&type=folder&id=17f7eb6faa2f47fdb3278e90d27fa318)